### PR TITLE
fixed HTTPS redirection.

### DIFF
--- a/cSploit/AndroidManifest.xml
+++ b/cSploit/AndroidManifest.xml
@@ -112,6 +112,10 @@
             android:configChanges="orientation|screenSize"
             android:label="@string/title_activity_main" />
         <activity
+            android:name=".plugins.mitm.DNSSpoofing"
+            android:configChanges="orientation|screenSize"
+            android:label="@string/title_activity_main" />
+        <activity
             android:name=".plugins.mitm.hijacker.Hijacker"
             android:configChanges="orientation|screenSize"
             android:label="@string/title_activity_main" />

--- a/cSploit/AndroidManifest.xml
+++ b/cSploit/AndroidManifest.xml
@@ -131,6 +131,11 @@
             android:name=".plugins.PacketForger"
             android:configChanges="orientation|screenSize"
             android:label="@string/title_activity_main" />
+        <activity
+            android:name=".gui.FileEdit"
+            android:label="@string/title_activity_file_edit"
+            android:parentActivityName=".plugins.mitm.PasswordSniffer" >
+        </activity>
     </application>
 
 </manifest>

--- a/cSploit/res/layout/plugin_mitm_dns_spoofing.xml
+++ b/cSploit/res/layout/plugin_mitm_dns_spoofing.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:focusable="true" android:focusableInTouchMode="true"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:orientation="vertical"
+                android:padding="8dp">
+
+    <ToggleButton
+            android:id="@+id/sniffToggleButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/toggle_button"
+            android:textOff="Start"
+            android:textOn="Stop"
+            android:paddingLeft="24dp"
+            android:paddingRight="24dp"
+            android:textAllCaps="true"
+            android:fontFamily="sans-serif-condensed"/>
+
+    <ProgressBar
+            android:id="@+id/sniffActivity"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentRight="true"
+            android:layout_alignTop="@+id/sniffToggleButton"
+            android:visibility="invisible"/>
+
+    <View
+            android:id="@+id/separator"
+            android:layout_width="fill_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            android:layout_below="@+id/sniffToggleButton"
+            android:background="@android:color/darker_gray"/>
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Save"
+        android:id="@+id/cmd_save"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true" />
+
+    <EditText
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:inputType="textMultiLine"
+        android:ems="10"
+        android:id="@+id/textViewDNSList"
+        android:layout_alignTop="@+id/separator"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:layout_above="@+id/cmd_save"
+        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true"
+        android:scrollbars="vertical|horizontal"
+        android:editable="true" />
+
+</RelativeLayout>

--- a/cSploit/res/values/strings.xml
+++ b/cSploit/res/values/strings.xml
@@ -319,6 +319,10 @@
     <string name="wifi_error_keys">Could not generate keys.</string>
     <string name="wifi_scan_finished">Scanning finished.</string>
 
+    <string name="mitm_dns_spoofing">DNS Spoofing</string>
+    <string name="mitm_dns_spoofing_desc">Redirect domains to a different web/IP</string>
+    <string name="mitm_dns_spoofing_list_saved">Saved</string>
+
     <!-- preferences -->
     <string name="pref_general">General</string>
     <string name="pref_modules">Modules</string>

--- a/cSploit/res/values/strings.xml
+++ b/cSploit/res/values/strings.xml
@@ -252,6 +252,7 @@
     <string name="mitm_simple_sniff_desc">Redirect target\'s traffic through this device and show some stats while dumping it to a pcap file.</string>
     <string name="mitm_password_sniff">Password Sniffer</string>
     <string name="mitm_password_sniff_desc">Sniff passwords of many protocols such as http, ftp, imap, imaps, irc, msn, etc from the target.</string>
+    <string name="mitm_password_sniff_menu_fields">Users/pass fields</string>
     <string name="mitm_session_hijack">Session Hijacker</string>
     <string name="mitm_session_hijack_desc">Listen for cookies on the network and hijack sessions.</string>
     <string name="mitm_connection_kill">Kill Connections</string>
@@ -445,6 +446,7 @@
     <string name="run">Run</string>
     <string name="command">Command</string>
     <string name="clear">Clear</string>
+    <string name="save">Save</string>
     <string name="msfrpc_disconnected">MSF RPC disconnected</string>
     <string name="no_opened_sessions">there is no opened sessions for this target</string>
     <string name="delete">Delete</string>

--- a/cSploit/src/org/csploit/android/plugins/mitm/DNSSpoofing.java
+++ b/cSploit/src/org/csploit/android/plugins/mitm/DNSSpoofing.java
@@ -1,0 +1,229 @@
+/*
+ * This file is part of the cSploit.
+ *
+ * Copyleft
+ *
+ * cSploit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cSploit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with cSploit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.csploit.android.plugins.mitm;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.support.v7.app.ActionBarActivity;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.widget.Toast;
+import android.widget.ToggleButton;
+
+import org.csploit.android.R;
+import org.csploit.android.core.ChildManager;
+import org.csploit.android.core.Logger;
+import org.csploit.android.core.System;
+import org.csploit.android.events.Event;
+import org.csploit.android.events.Message;
+import org.csploit.android.events.Newline;
+import org.csploit.android.tools.Ettercap;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class DNSSpoofing extends ActionBarActivity {
+    private ToggleButton mSniffToggleButton = null;
+	private ProgressBar mSniffProgress = null;
+	private TextView mTextDnsList = null;
+    private Button mCmdSave = null;
+	private boolean mRunning = false;
+	private FileWriter mFileWriter = null;
+	private BufferedWriter mBufferedWriter = null;
+	private SpoofSession mSpoofSession = null;
+
+    	public void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+
+		SharedPreferences themePrefs = getSharedPreferences("THEME", 0);
+		Boolean isDark = themePrefs.getBoolean("isDark", false);
+		if (isDark)
+			setTheme(R.style.DarkTheme);
+		else
+			setTheme(R.style.AppTheme);
+
+		setTitle(System.getCurrentTarget() + " > MITM > DNS spoofing");
+		setContentView(R.layout.plugin_mitm_dns_spoofing);
+		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+		mTextDnsList = (TextView) findViewById(R.id.textViewDNSList);
+        mCmdSave = (Button) findViewById(R.id.cmd_save);
+		mSniffToggleButton = (ToggleButton) findViewById(R.id.sniffToggleButton);
+		mSniffProgress = (ProgressBar) findViewById(R.id.sniffActivity);
+
+		mSpoofSession = new SpoofSession(false, false, null, null);
+
+        readDNSlist();
+
+		mSniffToggleButton.setOnClickListener(new View.OnClickListener() {
+			@Override
+			public void onClick(View v) {
+				if (mRunning) {
+					setStoppedState();
+				} else {
+					setStartedState();
+				}
+			}
+		});
+        mCmdSave.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                saveDNSlist();
+            }
+        });
+        }
+
+	@Override
+	public boolean onOptionsItemSelected(MenuItem item) {
+		switch (item.getItemId()) {
+		case android.R.id.home:
+
+			onBackPressed();
+
+			return true;
+
+		default:
+			return super.onOptionsItemSelected(item);
+		}
+	}
+
+    private void setStoppedState() {
+		mSpoofSession.stop();
+
+		try {
+			if (mBufferedWriter != null)
+				mBufferedWriter.close();
+		} catch (IOException e) {
+			System.errorLogging(e);
+		}
+
+		mSniffProgress.setVisibility(View.INVISIBLE);
+		mRunning = false;
+		mSniffToggleButton.setChecked(false);
+	}
+
+    public void readDNSlist(){
+        String _line="";
+
+        try {
+            BufferedReader inputReader = new BufferedReader(new FileReader(System.getContext().getFilesDir().getAbsolutePath() + "/tools/ettercap/share/etter.dns"));
+            while ((_line = inputReader.readLine()) != null) {
+                mTextDnsList.append(_line + "\n");
+            }
+
+            inputReader.close();
+        }
+        catch (Exception e){
+            Logger.error("readDNSList() error: " + e.getLocalizedMessage());
+        }
+    }
+
+    public void saveDNSlist(){
+
+        try {
+            Logger.info("saveDNSList() saving dnss to: " + System.getContext().getFilesDir().getAbsolutePath() + "/tools/ettercap/share/etter.dns");
+            File f = new File(System.getContext().getFilesDir().getAbsolutePath() + "/tools/ettercap/share/etter.dns");
+            FileOutputStream fos = new FileOutputStream(f);
+            fos.write(mTextDnsList.getText().toString().getBytes());
+            fos.close();
+
+            Toast.makeText(this, "Saved", Toast.LENGTH_SHORT).show();
+        }
+        catch (Exception e){
+            Logger.error("readDNSList() error: " + e.getLocalizedMessage());
+            Toast.makeText(this, "Error: " + e.getLocalizedMessage(), Toast.LENGTH_SHORT).show();
+        }
+    }
+
+	private void setStartedState() {
+
+    try {
+      mSpoofSession.start(new Ettercap.OnEventReceiver() {
+        @Override
+        public void onEvent(Event e) {
+            Logger.info("DNSSpoofing.onevent() e: " + e.toString());
+
+            if (e instanceof Message) {
+                Message m = (Message) e;
+                Logger.info("DNSSpoofing.OnEvent() error message from ettercap: " + m);
+            }
+            else if (e instanceof Newline){
+                Logger.info("DNSSpoofing.OnEvent() NewLine: " + e);
+            }
+        }
+
+        @Override
+        public void onStderr(String line)
+        {
+            if (line.contains("spoofed to"))
+                Toast.makeText(DNSSpoofing.this, line, Toast.LENGTH_LONG).show();
+        }
+
+        @Override
+        public void onEnd(final int exitValue) {
+          DNSSpoofing.this.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+              if(exitValue!=0) {
+                Toast.makeText(DNSSpoofing.this, "ettercap returned #" + exitValue, Toast.LENGTH_LONG).show();
+              }
+              setStoppedState();
+            }
+          });
+        }
+
+        @Override
+        public void onDeath(final int signal) {
+          DNSSpoofing.this.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+              Toast.makeText(DNSSpoofing.this, "ettercap killed by signal #" + signal, Toast.LENGTH_LONG).show();
+              setStoppedState();
+            }
+          });
+        }
+      });
+
+
+      mSniffProgress.setVisibility(View.VISIBLE);
+      mRunning = true;
+
+    } catch (ChildManager.ChildNotStartedException e) {
+      System.errorLogging(e);
+      mSniffToggleButton.setChecked(false);
+      Toast.makeText(DNSSpoofing.this, getString(R.string.child_not_started), Toast.LENGTH_LONG).show();
+    }
+	}
+
+	@Override
+	public void onBackPressed() {
+		setStoppedState();
+		super.onBackPressed();
+		overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_left);
+	}
+
+}

--- a/cSploit/src/org/csploit/android/plugins/mitm/DNSSpoofing.java
+++ b/cSploit/src/org/csploit/android/plugins/mitm/DNSSpoofing.java
@@ -33,9 +33,6 @@ import org.csploit.android.R;
 import org.csploit.android.core.ChildManager;
 import org.csploit.android.core.Logger;
 import org.csploit.android.core.System;
-import org.csploit.android.events.Event;
-import org.csploit.android.events.Message;
-import org.csploit.android.events.Newline;
 import org.csploit.android.tools.Ettercap;
 
 import java.io.BufferedReader;
@@ -162,18 +159,14 @@ public class DNSSpoofing extends ActionBarActivity {
 	private void setStartedState() {
 
     try {
-      mSpoofSession.start(new Ettercap.OnEventReceiver() {
+      mSpoofSession.start(new Ettercap.OnDNSSpoofedReceiver() {
         @Override
-        public void onEvent(Event e) {
-            Logger.info("DNSSpoofing.onevent() e: " + e.toString());
+        public void onSpoofed(String line) {
+            Logger.info("DNSSpoofing.onevent() line: " + line);
 
-            if (e instanceof Message) {
-                Message m = (Message) e;
-                Logger.info("DNSSpoofing.OnEvent() error message from ettercap: " + m);
-            }
-            else if (e instanceof Newline){
-                Logger.info("DNSSpoofing.OnEvent() NewLine: " + e);
-            }
+            if (line.contains("spoofed to"))
+                Toast.makeText(DNSSpoofing.this, line, Toast.LENGTH_LONG).show();
+
         }
 
         @Override
@@ -181,6 +174,10 @@ public class DNSSpoofing extends ActionBarActivity {
         {
             if (line.contains("spoofed to"))
                 Toast.makeText(DNSSpoofing.this, line, Toast.LENGTH_LONG).show();
+        }
+
+        @Override
+        public void onReady(){
         }
 
         @Override

--- a/cSploit/src/org/csploit/android/plugins/mitm/MITM.java
+++ b/cSploit/src/org/csploit/android/plugins/mitm/MITM.java
@@ -474,7 +474,7 @@ public class MITM extends Plugin
               (
                getString(R.string.mitm_dns_spoofing),
                getString(R.string.mitm_dns_spoofing_desc),
-               R.drawable.action_passwords,
+               R.drawable.action_redirect,
                new OnClickListener() {
                @Override
                public void onClick(View v) {

--- a/cSploit/src/org/csploit/android/plugins/mitm/MITM.java
+++ b/cSploit/src/org/csploit/android/plugins/mitm/MITM.java
@@ -420,29 +420,29 @@ public class MITM extends Plugin
     mScriptPicker.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
 
     mActions.add(new Action
-    (
-      getString(R.string.mitm_simple_sniff),
-      getString(R.string.mitm_simple_sniff_desc),
-      R.drawable.action_sniffer,
-      new OnClickListener(){
-        @Override
-        public void onClick(View v){
-          if(System.checkNetworking(MITM.this) == false)
-            return;
-
-          setStoppedState();
-
-          startActivity
             (
-              new Intent
-                (
-                  MITM.this,
-                  Sniffer.class
-                )
-            );
-          overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_left);
-        }
-      }));
+                    getString(R.string.mitm_simple_sniff),
+                    getString(R.string.mitm_simple_sniff_desc),
+                    R.drawable.action_sniffer,
+                    new OnClickListener() {
+                      @Override
+                      public void onClick(View v) {
+                        if (System.checkNetworking(MITM.this) == false)
+                          return;
+
+                        setStoppedState();
+
+                        startActivity
+                                (
+                                        new Intent
+                                                (
+                                                        MITM.this,
+                                                        Sniffer.class
+                                                )
+                                );
+                        overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_left);
+                      }
+                    }));
 
     mActions.add(new Action
     (
@@ -467,6 +467,32 @@ public class MITM extends Plugin
             );
           overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_left);
         }
+      }));
+
+
+      mActions.add(new Action
+              (
+               getString(R.string.mitm_dns_spoofing),
+               getString(R.string.mitm_dns_spoofing_desc),
+               R.drawable.action_passwords,
+               new OnClickListener() {
+               @Override
+               public void onClick(View v) {
+                    if (System.checkNetworking(MITM.this) == false)
+                       return;
+
+               setStoppedState();
+
+               startActivity
+               (
+                  new Intent
+                  (
+                     MITM.this,
+                     DNSSpoofing.class
+                  )
+               );
+               overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_left);
+                          }
       }));
 
     mActions.add(new Action

--- a/cSploit/src/org/csploit/android/plugins/mitm/PasswordSniffer.java
+++ b/cSploit/src/org/csploit/android/plugins/mitm/PasswordSniffer.java
@@ -19,10 +19,13 @@
 package org.csploit.android.plugins.mitm;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -34,6 +37,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.ToggleButton;
 
+import org.csploit.android.gui.FileEdit;
 import org.csploit.android.R;
 import org.csploit.android.core.ChildManager;
 import org.csploit.android.core.System;
@@ -57,6 +61,10 @@ public class PasswordSniffer extends ActionBarActivity {
 	private FileWriter mFileWriter = null;
 	private BufferedWriter mBufferedWriter = null;
 	private SpoofSession mSpoofSession = null;
+	private Menu mMenu = null;
+
+	private final static int OPTIONS_FIELDS = 0;
+	private final static int OPTIONS_FILTERS = 0;
 
 	public class ListViewAdapter extends BaseExpandableListAdapter {
 		private HashMap<String, ArrayList<String>> mGroups = null;
@@ -218,16 +226,38 @@ public class PasswordSniffer extends ActionBarActivity {
 	}
 
 	@Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.password_sniffer, menu);
+
+        mMenu = menu;
+
+        return super.onCreateOptionsMenu(menu);
+    }
+
+	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {
 		switch (item.getItemId()) {
-		case android.R.id.home:
+			case R.id.action_fields:
+				if (mSniffToggleButton.isEnabled() == false)
+					Toast.makeText(this, "The changes won't take effect until you stop the current traffic sniffing", Toast.LENGTH_SHORT).show();
 
-			onBackPressed();
+				Intent _fields = new Intent(PasswordSniffer.this, FileEdit.class);
+				_fields.putExtra(FileEdit.KEY_FILEPATH, "/tools/ettercap/share/etter.fields");
+				startActivityForResult(_fields, 0);
 
-			return true;
+				return true;
+			case R.id.action_filters:
+				Toast.makeText(this, "not implemented. yet", Toast.LENGTH_SHORT).show();
+				return true;
+			case android.R.id.home:
 
-		default:
-			return super.onOptionsItemSelected(item);
+				onBackPressed();
+
+				return true;
+
+			default:
+				return super.onOptionsItemSelected(item);
 		}
 	}
 

--- a/cSploit/src/org/csploit/android/plugins/mitm/SpoofSession.java
+++ b/cSploit/src/org/csploit/android/plugins/mitm/SpoofSession.java
@@ -97,10 +97,10 @@ public class SpoofSession
     System.setForwarding(true);
 
     if (mWithProxy) {
-      if (System.getSettings().getBoolean("PREF_HTTPS_REDIRECT", true))
-        System.getTools().ipTables.portRedirect(443, System.HTTPS_REDIR_PORT);
+      System.getTools().ipTables.portRedirect(80, System.HTTP_PROXY_PORT, true);
 
-      System.getTools().ipTables.portRedirect(80, System.HTTP_PROXY_PORT);
+      if (System.getSettings().getBoolean("PREF_HTTPS_REDIRECT", true))
+        System.getTools().ipTables.portRedirect(443, System.HTTPS_REDIR_PORT, false);
     }
 
     listener.onSessionReady();

--- a/cSploit/src/org/csploit/android/plugins/mitm/SpoofSession.java
+++ b/cSploit/src/org/csploit/android/plugins/mitm/SpoofSession.java
@@ -18,14 +18,15 @@
  */
 package org.csploit.android.plugins.mitm;
 
+import org.csploit.android.R;
 import org.csploit.android.core.Child;
 import org.csploit.android.core.ChildManager;
 import org.csploit.android.core.System;
 import org.csploit.android.net.Target;
 import org.csploit.android.tools.ArpSpoof;
-import org.csploit.android.tools.Ettercap;
 import org.csploit.android.tools.Ettercap.OnAccountListener;
-import org.csploit.android.R;
+import org.csploit.android.tools.Ettercap.OnDNSSpoofedReceiver;
+
 
 public class SpoofSession
 {
@@ -130,15 +131,15 @@ public class SpoofSession
     }
   }
 
-  public void start(final Ettercap.OnEventReceiver listener) throws ChildManager.ChildNotStartedException {
+  public void start(final OnDNSSpoofedReceiver listener) throws ChildManager.ChildNotStartedException {
 
-      mArpSpoofProcess =
-              System.getTools().arpSpoof.spoof(System.getCurrentTarget(), new ArpSpoof.ArpSpoofReceiver() {
-                @Override
-                public void onError(String line) {
-                  SpoofSession.this.stop();
-                }
-              });
+    mArpSpoofProcess =
+            System.getTools().arpSpoof.spoof(System.getCurrentTarget(), new ArpSpoof.ArpSpoofReceiver() {
+              @Override
+              public void onError(String line) {
+                SpoofSession.this.stop();
+              }
+            });
 
 
     try {

--- a/cSploit/src/org/csploit/android/plugins/mitm/SpoofSession.java
+++ b/cSploit/src/org/csploit/android/plugins/mitm/SpoofSession.java
@@ -23,6 +23,7 @@ import org.csploit.android.core.ChildManager;
 import org.csploit.android.core.System;
 import org.csploit.android.net.Target;
 import org.csploit.android.tools.ArpSpoof;
+import org.csploit.android.tools.Ettercap;
 import org.csploit.android.tools.Ettercap.OnAccountListener;
 import org.csploit.android.R;
 
@@ -127,6 +128,27 @@ public class SpoofSession
       this.stop();
       throw e;
     }
+  }
+
+  public void start(final Ettercap.OnEventReceiver listener) throws ChildManager.ChildNotStartedException {
+
+      mArpSpoofProcess =
+              System.getTools().arpSpoof.spoof(System.getCurrentTarget(), new ArpSpoof.ArpSpoofReceiver() {
+                @Override
+                public void onError(String line) {
+                  SpoofSession.this.stop();
+                }
+              });
+
+
+    try {
+      mEttercapProcess = System.getTools().ettercap.dnsSpoof(System.getCurrentTarget(), listener);
+    } catch (ChildManager.ChildNotStartedException e) {
+      this.stop();
+      throw e;
+    }
+
+    System.setForwarding(true);
   }
 
   public void start(final OnSessionReadyListener listener) throws ChildManager.ChildNotStartedException {

--- a/cSploit/src/org/csploit/android/tools/Ettercap.java
+++ b/cSploit/src/org/csploit/android/tools/Ettercap.java
@@ -52,6 +52,12 @@ public class Ettercap extends Tool
     public abstract void onReady();
   }
 
+
+    public abstract static class OnEventReceiver extends Child.EventReceiver {
+      public abstract void onEvent(Event e);
+      public abstract void onStderr(String line);
+    }
+
   public Child dissect(Target target, OnAccountListener listener) throws ChildManager.ChildNotStartedException {
     StringBuilder sb = new StringBuilder();
 
@@ -73,6 +79,35 @@ public class Ettercap extends Tool
       sb.append(target.getCommandLineRepresentation());
       sb.append("// ///");
     }
+
+    return super.async(sb.toString(), listener);
+  }
+
+  public Child dnsSpoof(Target target, OnEventReceiver listener) throws ChildManager.ChildNotStartedException {
+    StringBuilder sb = new StringBuilder();
+
+    sb.append("-Tq -P dns_spoof -i ");
+
+    try {
+      sb.append(System.getNetwork().getInterface().getDisplayName());
+    } catch (Exception e) {
+      System.errorLogging(e);
+      throw new ChildManager.ChildNotStartedException();
+    }
+
+    // poison the entire network
+    if(target.getType() == Target.Type.NETWORK) {
+      sb.append(" /// ///");
+      // router -> target poison
+    }
+    else {
+      sb.append(" /");
+      sb.append(target.getCommandLineRepresentation());
+      sb.append("// ");
+      sb.append(" ///");
+    }
+
+    //sb.append(" 1>&2 ");
 
     return super.async(sb.toString(), listener);
   }

--- a/cSploit/src/org/csploit/android/tools/IPTables.java
+++ b/cSploit/src/org/csploit/android/tools/IPTables.java
@@ -50,18 +50,20 @@ public class IPTables extends Tool
     }
   }
 
-  public void portRedirect(int from, int to){
+  public void portRedirect(int from, int to, boolean cleanRules){
     Logger.debug("Redirecting traffic from port " + from + " to port " + to);
 
     try{
-      // clear nat
-      super.run("-t nat -F");
-      // clear
-      super.run("-F");
-      // post route
-      super.run("-t nat -I POSTROUTING -s 0/0 -j MASQUERADE");
-      // accept all
-      super.run("-P FORWARD ACCEPT");
+      if (cleanRules) {
+        // clear nat
+        super.run("-t nat -F");
+        // clear
+        super.run("-F");
+        // post route
+        super.run("-t nat -I POSTROUTING -s 0/0 -j MASQUERADE");
+        // accept all
+        super.run("-P FORWARD ACCEPT");
+      }
       // add rule
       super.run("-t nat -A PREROUTING -j DNAT -p tcp --dport " + from + " --to " + System.getNetwork().getLocalAddressAsString() + ":" + to);
     }


### PR DESCRIPTION
see #233 for a more detailed explanation.

This was the behaviour when launching the session hijacker module:
- if configured HTTPS redirection: clean all the rules, add a new HTTPS rule.
- clean all the rules, and add the HTTP redirection rule.

so the HTTPS rule was was always deleted.