### PR TITLE
Changes to avoid deprecated setButton() (and add margins to InputDialog)

### DIFF
--- a/cSploit/src/org/csploit/android/gui/dialogs/AboutDialog.java
+++ b/cSploit/src/org/csploit/android/gui/dialogs/AboutDialog.java
@@ -42,7 +42,7 @@ public class AboutDialog extends AlertDialog{
     this.setTitle(activity.getString(R.string.about_csploit_v_) + System.getAppVersionName());
     this.setView(view);
 
-    this.setButton("Ok", new DialogInterface.OnClickListener() {
+    this.setButton(BUTTON_POSITIVE, "Ok", new DialogInterface.OnClickListener() {
       public void onClick(DialogInterface dialog, int id) {
         dialog.dismiss();
       }

--- a/cSploit/src/org/csploit/android/gui/dialogs/ChangelogDialog.java
+++ b/cSploit/src/org/csploit/android/gui/dialogs/ChangelogDialog.java
@@ -67,7 +67,7 @@ public class ChangelogDialog extends AlertDialog
     mLoader.dismiss();
 
     this.setCancelable(false);
-    this.setButton("Ok", new DialogInterface.OnClickListener(){
+    this.setButton(BUTTON_POSITIVE, "Ok", new DialogInterface.OnClickListener(){
       public void onClick(DialogInterface dialog, int id){
         dialog.dismiss();
       }

--- a/cSploit/src/org/csploit/android/gui/dialogs/ChoiceDialog.java
+++ b/cSploit/src/org/csploit/android/gui/dialogs/ChoiceDialog.java
@@ -62,7 +62,7 @@ public class ChoiceDialog extends AlertDialog{
     setView(layout);
 
 
-    this.setButton(activity.getString(R.string.cancel_dialog), new DialogInterface.OnClickListener(){
+    this.setButton(BUTTON_NEGATIVE, activity.getString(R.string.cancel_dialog), new DialogInterface.OnClickListener(){
       public void onClick(DialogInterface dialog, int id){
         dialog.dismiss();
       }

--- a/cSploit/src/org/csploit/android/gui/dialogs/ConfirmDialog.java
+++ b/cSploit/src/org/csploit/android/gui/dialogs/ConfirmDialog.java
@@ -39,13 +39,13 @@ public class ConfirmDialog extends AlertDialog{
 
     final ConfirmDialogListener listener = confirmDialogListener;
 
-    this.setButton(activity.getString(R.string.yes), new DialogInterface.OnClickListener(){
+    this.setButton(BUTTON_POSITIVE, activity.getString(R.string.yes), new DialogInterface.OnClickListener(){
       public void onClick(DialogInterface dialog, int id){
         listener.onConfirm();
       }
     });
 
-    this.setButton2(activity.getString(R.string.no), new DialogInterface.OnClickListener(){
+    this.setButton(BUTTON_NEGATIVE, activity.getString(R.string.no), new DialogInterface.OnClickListener(){
       public void onClick(DialogInterface dialog, int id){
         dialog.dismiss();
         listener.onCancel();

--- a/cSploit/src/org/csploit/android/gui/dialogs/CustomFilterDialog.java
+++ b/cSploit/src/org/csploit/android/gui/dialogs/CustomFilterDialog.java
@@ -25,9 +25,9 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;
 
-import java.util.ArrayList;
-
 import org.csploit.android.R;
+
+import java.util.ArrayList;
 
 public class CustomFilterDialog extends AlertDialog{
   public interface CustomFilterDialogListener{
@@ -42,7 +42,7 @@ public class CustomFilterDialog extends AlertDialog{
     this.setTitle(title);
     this.setView(view);
 
-    this.setButton("Ok", new DialogInterface.OnClickListener(){
+    this.setButton(BUTTON_POSITIVE, "Ok", new DialogInterface.OnClickListener(){
       public void onClick(DialogInterface dialog, int id){
         assert view != null;
         String f0 = ((EditText) view.findViewById(R.id.fromText0)).getText() + "".trim(),
@@ -88,7 +88,7 @@ public class CustomFilterDialog extends AlertDialog{
       }
     });
 
-    this.setButton2(activity.getString(R.string.cancel_dialog), new DialogInterface.OnClickListener(){
+    this.setButton(BUTTON_NEGATIVE, activity.getString(R.string.cancel_dialog), new DialogInterface.OnClickListener(){
       public void onClick(DialogInterface dialog, int id){
         dialog.dismiss();
       }

--- a/cSploit/src/org/csploit/android/gui/dialogs/ErrorDialog.java
+++ b/cSploit/src/org/csploit/android/gui/dialogs/ErrorDialog.java
@@ -29,7 +29,7 @@ public class ErrorDialog extends AlertDialog{
     this.setTitle(title);
     this.setMessage(message);
     this.setCancelable(false);
-    this.setButton("Ok", new DialogInterface.OnClickListener(){
+    this.setButton(BUTTON_POSITIVE, "Ok", new DialogInterface.OnClickListener(){
       public void onClick(DialogInterface dialog, int id){
         dialog.dismiss();
       }

--- a/cSploit/src/org/csploit/android/gui/dialogs/FatalDialog.java
+++ b/cSploit/src/org/csploit/android/gui/dialogs/FatalDialog.java
@@ -45,7 +45,7 @@ public class FatalDialog extends AlertDialog{
     }
 
     this.setCancelable(false);
-    this.setButton("Ok", new DialogInterface.OnClickListener(){
+    this.setButton(BUTTON_POSITIVE, "Ok", new DialogInterface.OnClickListener(){
       public void onClick(DialogInterface dialog, int id){
         activity.finish();
       }

--- a/cSploit/src/org/csploit/android/gui/dialogs/FinishDialog.java
+++ b/cSploit/src/org/csploit/android/gui/dialogs/FinishDialog.java
@@ -29,7 +29,7 @@ public class FinishDialog extends AlertDialog{
     this.setTitle(title);
     this.setMessage(message);
     this.setCancelable(false);
-    this.setButton("Ok", new DialogInterface.OnClickListener(){
+    this.setButton(BUTTON_POSITIVE, "Ok", new DialogInterface.OnClickListener(){
       public void onClick(DialogInterface dialog, int id){
         dialog.dismiss();
         activity.finish();

--- a/cSploit/src/org/csploit/android/gui/dialogs/InputDialog.java
+++ b/cSploit/src/org/csploit/android/gui/dialogs/InputDialog.java
@@ -53,19 +53,19 @@ public class InputDialog extends AlertDialog{
 
     this.setTitle(title);
     this.setMessage(message);
-    this.setView(mEditText);
+
+    this.setView(mEditText, 40, 0, 40, 0);
 
     final InputDialogListener listener = inputDialogListener;
-
-    this.setButton("Ok", new DialogInterface.OnClickListener(){
-      public void onClick(DialogInterface dialog, int id){
+    this.setButton(BUTTON_POSITIVE, "Ok", new DialogInterface.OnClickListener() {
+      public void onClick(DialogInterface dialog, int id) {
         if(listener != null)
           listener.onInputEntered(mEditText.getText() + "");
       }
     });
 
-    this.setButton2(activity.getString(R.string.cancel_dialog), new DialogInterface.OnClickListener(){
-      public void onClick(DialogInterface dialog, int id){
+    this.setButton(BUTTON_NEGATIVE, activity.getString(R.string.cancel_dialog), new DialogInterface.OnClickListener() {
+      public void onClick(DialogInterface dialog, int id) {
         dialog.dismiss();
       }
     });

--- a/cSploit/src/org/csploit/android/gui/dialogs/ListChoiceDialog.java
+++ b/cSploit/src/org/csploit/android/gui/dialogs/ListChoiceDialog.java
@@ -57,7 +57,7 @@ public class ListChoiceDialog extends AlertDialog{
     setTitle(activity.getString(title));
     setView(mList);
 
-    setButton(activity.getString(R.string.cancel_dialog), new OnClickListener(){
+    setButton(BUTTON_NEGATIVE, activity.getString(R.string.cancel_dialog), new OnClickListener(){
       public void onClick(DialogInterface dialog, int id){
         dialog.dismiss();
       }
@@ -85,7 +85,7 @@ public class ListChoiceDialog extends AlertDialog{
     this.setTitle(title);
     this.setView(mList);
 
-    this.setButton(activity.getString(R.string.cancel_dialog), new OnClickListener(){
+    this.setButton(BUTTON_NEGATIVE, activity.getString(R.string.cancel_dialog), new OnClickListener(){
       public void onClick(DialogInterface dialog, int id){
         dialog.dismiss();
       }
@@ -118,7 +118,7 @@ public class ListChoiceDialog extends AlertDialog{
     this.setTitle(title);
     this.setView(mList);
 
-    this.setButton(activity.getString(R.string.cancel_dialog), new OnClickListener(){
+    this.setButton(BUTTON_NEGATIVE, activity.getString(R.string.cancel_dialog), new OnClickListener(){
       public void onClick(DialogInterface dialog, int id){
         dialog.dismiss();
       }

--- a/cSploit/src/org/csploit/android/gui/dialogs/MultipleChoiceDialog.java
+++ b/cSploit/src/org/csploit/android/gui/dialogs/MultipleChoiceDialog.java
@@ -95,12 +95,12 @@ public class MultipleChoiceDialog extends AlertDialog{
     this.setTitle(title);
     this.setView(mList);
 
-    setButton(activity.getString(R.string.cancel_dialog), new OnClickListener(){
+    setButton(BUTTON_NEGATIVE, activity.getString(R.string.cancel_dialog), new OnClickListener(){
       public void onClick(DialogInterface dialog, int id){
         dialog.dismiss();
       }
     });
-    setButton2(activity.getString(R.string.choose), new OnClickListener() {
+    setButton(BUTTON_POSITIVE, activity.getString(R.string.choose), new OnClickListener() {
       @Override
       public void onClick(DialogInterface dialog, int which) {
         int count = 0;

--- a/cSploit/src/org/csploit/android/gui/dialogs/RedirectionDialog.java
+++ b/cSploit/src/org/csploit/android/gui/dialogs/RedirectionDialog.java
@@ -36,7 +36,7 @@ public class RedirectionDialog extends AlertDialog{
     this.setTitle(title);
     this.setView(view);
 
-    this.setButton("Ok", new DialogInterface.OnClickListener(){
+    this.setButton(BUTTON_POSITIVE, "Ok", new DialogInterface.OnClickListener(){
       public void onClick(DialogInterface dialog, int id){
         assert view != null;
         String address = ((EditText) view.findViewById(R.id.redirAddress)).getText() + "".trim(),
@@ -46,8 +46,8 @@ public class RedirectionDialog extends AlertDialog{
       }
     });
 
-    this.setButton2(activity.getString(R.string.cancel_dialog), new DialogInterface.OnClickListener(){
-      public void onClick(DialogInterface dialog, int id){
+    this.setButton(BUTTON_NEGATIVE, activity.getString(R.string.cancel_dialog), new DialogInterface.OnClickListener() {
+      public void onClick(DialogInterface dialog, int id) {
         dialog.dismiss();
       }
     });

--- a/cSploit/src/org/csploit/android/gui/dialogs/SpinnerDialog.java
+++ b/cSploit/src/org/csploit/android/gui/dialogs/SpinnerDialog.java
@@ -53,14 +53,14 @@ public class SpinnerDialog extends AlertDialog{
     this.setMessage(message);
     this.setView(mSpinner);
 
-    this.setButton("Ok", new DialogInterface.OnClickListener(){
+    this.setButton(BUTTON_POSITIVE, "Ok", new DialogInterface.OnClickListener(){
       public void onClick(DialogInterface dialog, int id){
         listener.onItemSelected(mSelected);
       }
     });
 
-    this.setButton2(activity.getString(R.string.cancel_dialog), new DialogInterface.OnClickListener(){
-      public void onClick(DialogInterface dialog, int id){
+    this.setButton(BUTTON_NEGATIVE, activity.getString(R.string.cancel_dialog), new DialogInterface.OnClickListener() {
+      public void onClick(DialogInterface dialog, int id) {
         dialog.dismiss();
       }
     });

--- a/cSploit/src/org/csploit/android/gui/dialogs/WifiCrackDialog.java
+++ b/cSploit/src/org/csploit/android/gui/dialogs/WifiCrackDialog.java
@@ -42,22 +42,22 @@ public class WifiCrackDialog extends AlertDialog{
 
     final WifiCrackDialogListener listener = wifiCrackDialogListener;
 
-    this.setButton(activity.getString(R.string.connect), new DialogInterface.OnClickListener(){
+    this.setButton(BUTTON_POSITIVE, activity.getString(R.string.connect), new DialogInterface.OnClickListener(){
       public void onClick(DialogInterface dialog, int id){
         if(listener != null)
           listener.onManualConnect(mEditText.getText() + "");
       }
     });
 
-    this.setButton2(activity.getString(R.string.crack), new DialogInterface.OnClickListener(){
-      public void onClick(DialogInterface dialog, int id){
-        if(listener != null)
+    this.setButton(BUTTON_NEUTRAL, activity.getString(R.string.crack), new DialogInterface.OnClickListener() {
+      public void onClick(DialogInterface dialog, int id) {
+        if (listener != null)
           listener.onCrack();
       }
     });
 
-    this.setButton3(activity.getString(R.string.cancel_dialog), new DialogInterface.OnClickListener(){
-      public void onClick(DialogInterface dialog, int id){
+    this.setButton(BUTTON_NEGATIVE, activity.getString(R.string.cancel_dialog), new DialogInterface.OnClickListener() {
+      public void onClick(DialogInterface dialog, int id) {
         dialog.dismiss();
       }
     });


### PR DESCRIPTION
This is just a quick fix to SetButton() which as of API 3 (three!) wants to be told the kind of button it is.  Also, The margins on the InputDialog was kind of weird, so I played with margins and 40 (left/right) seemed to look okay.  Conceptually 40 seems like a lot, but when I looked at the result it looked right.

Anyway, try it, and if 40 isn't good on various devices, feel free to change it.

