### PR TITLE
Quick and dirty MSF RPC daemon status notification

### DIFF
--- a/cSploit/res/values/colors.xml
+++ b/cSploit/res/values/colors.xml
@@ -10,4 +10,9 @@
     <color name="holo_blue_dark">#ff0d222f</color>
     <color name="selectable_blue">#ff36ccff</color>
     <color name="selectable_blue_dark">#ff144d5d</color>
+    <color name="pink">#E91E63</color>
+    <color name="red">#F44336</color>
+    <color name="green">#4CAF50</color>
+    <color name="purple">#3F51B5</color>
+    <color name="orange">#FFC107</color>
 </resources>

--- a/cSploit/res/values/strings.xml
+++ b/cSploit/res/values/strings.xml
@@ -237,15 +237,11 @@
     <string name="error_rpc">RPC error</string>
     <string name="error_rpcd_inval">bad settings</string>
     <string name="error_rpcd_shell">cannot execute shell</string>
-    <string name="rpcd_starting">Starting MetaSploit RPCD&#8230;</string>
+    <string name="rpcd_starting">Starting MetaSploit RPCD.  Standby&#8230;</string>
     <string name="rpcd_started">MetaSploit RPCD started</string>
     <string name="rpcd_stopped">MetaSploit RPCD stopped</string>
     <string name="rpcd_running">MetaSploit RPCD is already running</string>
     <string name="rpcd_timedout">MetaSploit RPCD does not respond</string>
-    <string name="error_rcpd_fatal">fatal error occurred, i\'m searching that bug for send it to my developers.
-        if i won\'t exit please close me from preferences->applications,
-        and ALERT MY DEVELOPERS.
-    </string>
 
     <!-- mitm modules -->
     <string name="mitm_simple_sniff">Simple Sniff</string>
@@ -400,6 +396,8 @@
     <string name="pref_folder">Folder</string>
     <string name="pref_msf_enable">Enable MSF</string>
     <string name="pref_msf_enable_desc">Enable the MetaSploit Framework</string>
+    <string name="pref_msf_notifications">MSF status notifications</string>
+    <string name="pref_msf_notifications_desc">View MSF RPC connection status</string>
     <string name="pref_msf_delete">Delete MSF</string>
     <string name="pref_msf_delete_desc">Delete the MetaSploit Framework from your device</string>
     <string name="pref_msfwipe_message">Do you really want to delete the MetaSploit Framework?</string>

--- a/cSploit/res/xml-v14/preferences.xml
+++ b/cSploit/res/xml-v14/preferences.xml
@@ -163,6 +163,12 @@
             android:title="@string/pref_msf_enable"
             android:summary="@string/pref_msf_enable_desc" />
 
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="MSF_NOTIFICATIONS"
+            android:title="@string/pref_msf_notifications"
+            android:summary="@string/pref_msf_notifications_desc" />
+
         <ListPreference
             android:key="MSF_BRANCH"
             android:summary="@string/pref_msf_branch_desc"

--- a/cSploit/res/xml/preferences.xml
+++ b/cSploit/res/xml/preferences.xml
@@ -163,6 +163,12 @@
             android:title="@string/pref_msf_enable"
             android:summary="@string/pref_msf_enable_desc" />
 
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="MSF_NOTIFICATIONS"
+            android:title="@string/pref_msf_notifications"
+            android:summary="@string/pref_msf_notifications_desc" />
+
         <ListPreference
             android:key="MSF_BRANCH"
             android:summary="@string/pref_msf_branch_desc"


### PR DESCRIPTION
This may not be the ultimate way to do this, but seems to work.  Basically, I've been getting
tripped up on what's the status of the connection to the MSF daemon if I missed the toast.
This lets me see at a glance what the current status is.

It's on by default but you can turn it off in preferences.  Eventually we might want to replace
the toast with a material-esque Snackbar.

![ss](https://i.imgur.com/9FeUgQg.jpg)