### PR TITLE
Some improvements to ExploitFinder

### DIFF
--- a/cSploit/res/layout/plugin_exploit_finder_item.xml
+++ b/cSploit/res/layout/plugin_exploit_finder_item.xml
@@ -24,12 +24,21 @@
         android:fontFamily="sans-serif-condensed"
         android:textSize="16sp"/>
 
+
     <TextView
-        android:id="@+id/itemDescription"
+        android:id="@+id/itemRanking"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/itemTitle"
         android:layout_toRightOf="@id/itemIcon"
-        android:textSize="13sp"/>
+        android:textSize="12sp"/>
+
+    <TextView
+        android:id="@+id/itemDescription"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/itemRanking"
+        android:layout_toRightOf="@id/itemIcon"
+        android:textSize="14sp"/>
 
 </RelativeLayout>

--- a/cSploit/src/org/csploit/android/plugins/ExploitFinder.java
+++ b/cSploit/src/org/csploit/android/plugins/ExploitFinder.java
@@ -21,9 +21,11 @@ package org.csploit.android.plugins;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.graphics.Color;
 import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 import android.text.Html;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -61,6 +63,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
 
+import static org.csploit.android.net.metasploit.MsfExploit.Ranking;
+
 public class ExploitFinder extends Plugin {
     private ToggleButton mSearchToggleButton = null;
     private ProgressBar mSearchProgress = null;
@@ -75,6 +79,7 @@ public class ExploitFinder extends Plugin {
             ImageView itemImage;
             TextView itemTitle;
             TextView itemDescription;
+            TextView itemRanking;
         }
 
         public ExploitAdapter() {
@@ -95,6 +100,7 @@ public class ExploitFinder extends Plugin {
                 holder.itemImage = (ImageView) row.findViewById(R.id.itemIcon);
                 holder.itemTitle = (TextView) row.findViewById(R.id.itemTitle);
                 holder.itemDescription = (TextView) row.findViewById(R.id.itemDescription);
+                holder.itemRanking = (TextView) row.findViewById(R.id.itemRanking);
 
                 row.setTag(holder);
             } else {
@@ -111,10 +117,46 @@ public class ExploitFinder extends Plugin {
                                                 "<b>" + exploit.getName() + "</b>"
                                         )
                         );
+                final Ranking rank = ((MsfExploit) exploit).getRank();
+                String rString = "Ranking:  ";
+                String color;
+                switch (rank) {
+                    case Low:
+                        rString+= "Low";
+                        color = "red";
+                        break;
+                    case Average:
+                        rString+= "Average";
+                        color = "grey4";
+                        break;
+                    case Normal:
+                        rString+= "Normal";
+                        color = "grey4";
+                        break;
+                    case Good:
+                        rString+= "Good";
+                        color = "blue";
+                        break;
+                    case Great:
+                        rString+= "Great";
+                        color = "green";
+                        break;
+                    case Excellent:
+                        rString+= "Excellent";
+                        color = "green";
+                        break;
+                    case Manual:
+                    default:
+                        rString+= "Manual";
+                        color = "gray4";
+                        break;
+                }
+
+                holder.itemRanking.setText(Html.fromHtml("<font color=\"" + color + "\">" + rString + "</font>"));
             } else
                 holder.itemTitle.setText(exploit.getName());
 
-            holder.itemTitle.setTextColor(getResources().getColor(
+            holder.itemTitle.setTextColor(ContextCompat.getColor(getContext(),
                     exploit.isEnabled() ? R.color.app_color : R.color.gray_text));
             holder.itemTitle.setTypeface(null, Typeface.NORMAL);
             holder.itemImage.setImageResource(exploit.getDrawableResourceId());
@@ -155,36 +197,7 @@ public class ExploitFinder extends Plugin {
                         Intent intent;
                         switch (availableChoices.get(choice)) {
                             case R.string.exploit_launch:
-                                new Thread(new Runnable() {
-                                  @Override
-                                  public void run() {
-
-                                    int length;
-                                    String message;
-
-                                    length = Toast.LENGTH_SHORT;
-
-                                    try {
-                                      if (msfEx.launch())
-                                        message = "Job started";
-                                      else
-                                        message = "launch failed";
-                                    } catch (RPCClient.MSFException e) {
-                                      message = String.format("launch failed: %s", e.getMessage());
-                                      length = Toast.LENGTH_LONG;
-                                    }
-
-                                    final int flength = length;
-                                    final String fmessage = message;
-
-                                    ExploitFinder.this.runOnUiThread(new Runnable() {
-                                      @Override
-                                      public void run() {
-                                        Toast.makeText(ExploitFinder.this, fmessage, flength).show();
-                                      }
-                                    });
-                                  }
-                                }).start();
+                                launchExploit(msfEx);
                                 break;
                             case R.string.exploit_edit_options:
                                 intent = new Intent(ExploitFinder.this, MsfPreferences.class);
@@ -227,6 +240,40 @@ public class ExploitFinder extends Plugin {
             }
         }
     };
+
+    public void launchExploit(final MsfExploit msfEx) {
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+
+                int length;
+                String message;
+
+                length = Toast.LENGTH_SHORT;
+
+                try {
+                    if (msfEx.launch())
+                        message = msfEx.getName() + ":  Job started";
+                    else
+                        message = msfEx.getName() + ":  Launch failed";
+                } catch (RPCClient.MSFException e) {
+                    message = String.format("launch failed: %s", e.getMessage());
+                    length = Toast.LENGTH_LONG;
+                }
+
+                final int flength = length;
+                final String fmessage = message;
+
+                ExploitFinder.this.runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        Toast.makeText(ExploitFinder.this, fmessage, flength).show();
+                    }
+                });
+            }
+        }).start();
+    }
 
     public ExploitFinder() {
         super
@@ -351,6 +398,13 @@ public class ExploitFinder extends Plugin {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.exploit_launch_all:
+                mAdapter.getCount();
+                for (int x=0; x < mAdapter.getCount(); x++) {
+                    Exploit exp = mAdapter.getItem(x);
+                    if (exp instanceof MsfExploit) {
+                        launchExploit((MsfExploit) exp);
+                    }
+                }
                 return true;
             default:
                 return super.onOptionsItemSelected(item);


### PR DESCRIPTION
*  Show color-coded Ranking for each exploit
*  Wire up the "Launch All" to actually try MSFExploits on list.. it just goes down the list firing stuff.

<img src="https://i.imgur.com/W45mdjk.jpg" width=240>

Both could be improved.  Just an initial try at this.  The "hail mary" feature seems to work but could be nicer if it used in combination with [the notification stuff I did yesterday](https://gist.github.com/fat-tire/1a219f2935f673954109).