### PR TITLE
Speed up port protocol resolution.

### DIFF
--- a/cSploit/src/org/csploit/android/core/System.java
+++ b/cSploit/src/org/csploit/android/core/System.java
@@ -38,6 +38,7 @@ import android.util.SparseIntArray;
 
 import org.acra.ACRA;
 import org.acra.ACRAConfiguration;
+import org.apache.commons.compress.utils.IOUtils;
 import org.csploit.android.R;
 import org.csploit.android.WifiScannerActivity;
 import org.csploit.android.gui.dialogs.FatalDialog;
@@ -151,10 +152,10 @@ public class System
       mStoragePath = getSettings().getString("PREF_SAVE_PATH", Environment.getExternalStorageDirectory().toString());
       mSessionName = "csploit-session-" + java.lang.System.currentTimeMillis();
       mKnownIssues = new KnownIssues();
-      mPlugins = new ArrayList<Plugin>();
+      mPlugins = new ArrayList<>();
       mOpenPorts = new SparseIntArray(3);
-      mServices = new HashMap<String, String>();
-      mPorts = new HashMap<String, String>();
+      mServices = new HashMap<>();
+      mPorts = new HashMap<>();
 
       // if we are here, network initialization didn't throw any error, lock wifi
       WifiManager wifiManager = (WifiManager) mContext.getSystemService(Context.WIFI_SERVICE);
@@ -520,7 +521,7 @@ public class System
   }
 
   public static void preloadServices(){
-    if (mServices.size() > 0 && mPorts.size() > 0)
+    if (!mServices.isEmpty())
       return;
 
     FileReader fr = null;
@@ -528,7 +529,6 @@ public class System
     try{
       // preload network service and ports map
 
-      //@SuppressWarnings("ConstantConditions")
       fr = new FileReader(mContext.getFilesDir().getAbsolutePath() + "/tools/nmap/nmap-services");
       reader = new BufferedReader(fr);
       String line;
@@ -550,15 +550,9 @@ public class System
       mPorts.clear();
 
       errorLogging(e);
-    }
-    finally {
-      try {
-        if (fr != null)
-          fr.close();
-        if (reader != null)
-          reader.close();
-      }
-      catch (Exception e){}
+    } finally {
+      IOUtils.closeQuietly(reader);
+      IOUtils.closeQuietly(fr);
     }
   }
 

--- a/cSploit/src/org/csploit/android/plugins/PortScanner.java
+++ b/cSploit/src/org/csploit/android/plugins/PortScanner.java
@@ -69,7 +69,6 @@ public class PortScanner extends Plugin {
 	private static final String CUSTOM_PARAMETERS = "PortScanner.Prefs.CustomParameters";
 	private static final String CUSTOM_PARAMETERS_TEXT = "PortScanner.Prefs.CustomParameters.Text";
 	private SharedPreferences mPreferences = null;
-	private boolean unresolvedPorts = false;
 
 	public PortScanner() {
 		super(R.string.port_scanner, R.string.port_scanner_desc,
@@ -111,7 +110,7 @@ public class PortScanner extends Plugin {
 		SharedPreferences.Editor edit = mPreferences.edit();
 		edit.putBoolean(CUSTOM_PARAMETERS, displayed);
 		edit.putString(CUSTOM_PARAMETERS_TEXT, mTextParameters.getText().toString());
-		edit.commit();
+		edit.apply();
 	}
 
 	private void setStoppedState() {
@@ -390,29 +389,6 @@ public class PortScanner extends Plugin {
 		public void onEnd(int exitCode) {
 			super.onEnd(exitCode);
 
-			// last chance to resolve ports protocols
-			if (unresolvedPorts) {
-				String temp_port, port, protocol;
-				for (int i = 0; i < mPortList.size(); i++) {
-					if (mPortList.get(i).startsWith("tcp : ") || mPortList.get(i).startsWith("udp : ")) {
-						temp_port = mPortList.get(i);
-						port = temp_port.split("\\s")[2];
-						protocol = System.getProtocolByPort(port);
-
-						if (protocol != null)
-							mPortList.set(i, port + " ( " + protocol + " )");
-
-						Logger.debug("unresolved port: " + port + ":" + protocol);
-					}
-				}
-				PortScanner.this.runOnUiThread(new Runnable() {
-					@Override
-					public void run() {
-						mListAdapter.notifyDataSetChanged();
-					}
-				});
-			}
-
 			PortScanner.this.runOnUiThread(new Runnable() {
 				@Override
 				public void run() {
@@ -433,11 +409,9 @@ public class PortScanner extends Plugin {
 				public void run() {
           String entry;
 
-					if (resolvedProtocol != null)
+					if (resolvedProtocol != null) {
 						entry = port + " ( " + resolvedProtocol + " )";
-
-					else {
-						unresolvedPorts = true;
+					} else {
 						entry = portProtocol + " : " + port;
 					}
 


### PR DESCRIPTION
Workaround for #332. Instead of loading services when we find a new open port, do it when we select the port scanner activity, and in a new thread. Thus when we start a new port scan and a new open port is discovered, it has already loaded ~2000 ports (1ghz).
Also avoid to create new objects on every iteration of a loop.

On the other hand it also prevents a NPE if the user closes the app before loading the services.