### PR TITLE
Allow to select a target from the Simple Sniff module.

### DIFF
--- a/cSploit/res/values/strings.xml
+++ b/cSploit/res/values/strings.xml
@@ -514,4 +514,6 @@
     <string name="new_ruby_found">A new version for ruby is available, do you want to upgrade ?</string>
     <string name="new_msf_found">A new msf version is available, do you want to upgrade ?</string>
     <string name="msf_status">MetaSploit Status</string>
+    <string name="mitm_ss_select_target_title">Select target</string>
+    <string name="mitm_ss_select_target_prompt">Select %s ?</string>
 </resources>

--- a/cSploit/src/org/csploit/android/core/System.java
+++ b/cSploit/src/org/csploit/android/core/System.java
@@ -1029,16 +1029,20 @@ public class System
     return mTargets.get(index);
   }
 
-  public static int getTargetPosition (Target t) {
-    return mTargets.indexOf(t);
-  }
-
   public static boolean hasTarget(Target target){
     return mTargets.contains(target);
   }
 
   public static void setCurrentTarget(int index){
     mCurrentTarget = index;
+  }
+
+  public static void setCurrentTarget(Target target) {
+    int index = mTargets.indexOf(target);
+    if(index != -1)
+      setCurrentTarget(index);
+    else
+      Logger.error("target '" + target + "' not found");
   }
 
   public static Target getCurrentTarget(){

--- a/cSploit/src/org/csploit/android/core/System.java
+++ b/cSploit/src/org/csploit/android/core/System.java
@@ -21,9 +21,7 @@ package org.csploit.android.core;
 import android.app.Activity;
 import android.app.ActivityManager;
 import android.app.ActivityManager.RunningServiceInfo;
-import android.app.AlertDialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
@@ -32,7 +30,6 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.net.wifi.WifiManager;
 import android.net.wifi.WifiManager.WifiLock;
 import android.os.Build;
-import android.os.Bundle;
 import android.os.Environment;
 import android.os.PowerManager;
 import android.os.PowerManager.WakeLock;
@@ -1030,6 +1027,10 @@ public class System
 
   public static Target getTarget(int index){
     return mTargets.get(index);
+  }
+
+  public static int getTargetPosition (Target t) {
+    return mTargets.indexOf(t);
   }
 
   public static boolean hasTarget(Target target){


### PR DESCRIPTION
When using the Simple sniff module to see which hosts are sending traffic on the subnet, allow to select them as target by clicking on them.