### PR TITLE
Extract charset encoding from HTTP headers or HTML headers.

### DIFF
--- a/cSploit/src/main/java/org/csploit/android/net/http/RequestParser.java
+++ b/cSploit/src/main/java/org/csploit/android/net/http/RequestParser.java
@@ -505,8 +505,7 @@ public class RequestParser
    */
   public static String getCharsetFromBody(String body) {
     if (body != null) {
-      // match <body>, <body onLoad="">, etc...
-      int headEnd = body.toLowerCase().indexOf("</head>");
+      int headEnd = body.toLowerCase().trim().indexOf("</head>");
 
       // return null if there's no head tags
       if (headEnd == -1)
@@ -514,10 +513,13 @@ public class RequestParser
 
       String body_head = body.toLowerCase().substring(0, headEnd);
 
-      Pattern p = Pattern.compile("charset=([\"a-z0-9A-Z-]+)");
+      Pattern p = Pattern.compile("charset=([\"\'a-z0-9A-Z-]+)");
       Matcher m = p.matcher(body_head);
-      if (m.find())
-        return m.toMatchResult().group(1).replaceAll("\"", "");
+      String str_match = "";
+      if (m.find()) {
+        str_match = m.toMatchResult().group(1);
+        return str_match.replaceAll("[\"']", "");
+      }
     }
 
     return null;

--- a/cSploit/src/main/java/org/csploit/android/net/http/RequestParser.java
+++ b/cSploit/src/main/java/org/csploit/android/net/http/RequestParser.java
@@ -27,6 +27,8 @@ import java.net.HttpCookie;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class RequestParser
 {
@@ -474,6 +476,48 @@ public class RequestParser
       }
 
       return cookies.size() > 0 ? cookies : null;
+    }
+
+    return null;
+  }
+
+  /**
+   * extract the charset encoding from the HTTP response headers.
+   *
+   * @param contentType content-type header to be parsed
+   * @return returns the charset encoding if we've found it, or null.
+   */
+  public static String getCharsetFromHeaders(String contentType){
+    if (contentType != null && contentType.toLowerCase().trim().contains("charset=")){
+      String[] parts = contentType.toLowerCase().trim().split("=");
+      if (parts.length > 0)
+        return parts[1];
+    }
+
+    return null;
+  }
+
+  /**
+   * extract the charset encoding of a web site from the <meta> headers.
+   *
+   * @param body html body of the site to be parsed
+   * @return returns the charset encoding if we've found it, or null.
+   */
+  public static String getCharsetFromBody(String body) {
+    if (body != null) {
+      // match <body>, <body onLoad="">, etc...
+      int headEnd = body.toLowerCase().indexOf("</head>");
+
+      // return null if there's no head tags
+      if (headEnd == -1)
+        return null;
+
+      String body_head = body.toLowerCase().substring(0, headEnd);
+
+      Pattern p = Pattern.compile("charset=([\"a-z0-9A-Z-]+)");
+      Matcher m = p.matcher(body_head);
+      if (m.find())
+        return m.toMatchResult().group(1).replaceAll("\"", "");
     }
 
     return null;

--- a/cSploit/src/main/java/org/csploit/android/net/http/proxy/StreamThread.java
+++ b/cSploit/src/main/java/org/csploit/android/net/http/proxy/StreamThread.java
@@ -27,6 +27,7 @@ import org.csploit.android.net.http.RequestParser;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 
 public class StreamThread implements Runnable
 {
@@ -168,7 +169,13 @@ public class StreamThread implements Runnable
         }
 
         if (charset != null) {
-          mBuffer.setData((headers + HEAD_SEPARATOR + body).getBytes(charset));
+          try {
+            mBuffer.setData((headers + HEAD_SEPARATOR + body).getBytes(charset));
+          }
+          catch (UnsupportedEncodingException e){
+            Logger.error("UnsupportedEncoding: " + e.getLocalizedMessage());
+            mBuffer.setData((headers + HEAD_SEPARATOR + body).getBytes());
+          }
         }
         else {
           // if we haven't found the charset encoding, just handle it on ByteBuffer()


### PR DESCRIPTION
Workaround for #451 and #50.

ByteBuffer() using UniversalDetector fails to detect and set the charset encoding when redirecting the intecepted html to the browser of the target.
The way I've found of fix it is by extracting the charset from the HTTP headers or from the HTML <head>, and set it when redirecting the html to the target.