### PR TITLE
Added a simple cache for already resolved TLDs.

### DIFF
--- a/cSploit/src/main/java/org/csploit/android/net/http/RequestParser.java
+++ b/cSploit/src/main/java/org/csploit/android/net/http/RequestParser.java
@@ -22,6 +22,7 @@ import android.util.Patterns;
 
 import org.csploit.android.core.Logger;
 import org.csploit.android.net.ByteBuffer;
+import org.csploit.android.net.http.proxy.DNSCache;
 
 import java.net.HttpCookie;
 import java.util.ArrayList;
@@ -296,6 +297,11 @@ public class RequestParser
     if(Patterns.IP_ADDRESS.matcher(hostname).matches())
       return hostname;
 
+    String cached_domain = DNSCache.getInstance().getCachedRootDomain(hostname);
+    if (cached_domain != null) {
+      return cached_domain;
+    }
+
     for(String tld : TLD){
       if(hostname.endsWith(tld)){
         String[] host_parts = hostname.split("\\."),
@@ -312,6 +318,7 @@ public class RequestParser
           domain += host_parts[i] + ".";
         }
 
+        DNSCache.getInstance().addCachedRootDomain(domain.substring(0, domain.length() - 1));
         return domain.substring(0, domain.length() - 1);
       }
     }
@@ -320,14 +327,15 @@ public class RequestParser
       nextIndex = hostname.indexOf('.'),
       lastIndex = hostname.lastIndexOf('.');
 
-    while(nextIndex < lastIndex){
+    while(nextIndex < lastIndex) {
       startIndex = nextIndex + 1;
       nextIndex = hostname.indexOf('.', startIndex);
     }
 
-    if(startIndex > 0)
+    if(startIndex > 0) {
+      DNSCache.getInstance().addCachedRootDomain(hostname.substring(startIndex));
       return hostname.substring(startIndex);
-
+    }
     else
       return hostname;
   }

--- a/cSploit/src/main/java/org/csploit/android/net/http/RequestParser.java
+++ b/cSploit/src/main/java/org/csploit/android/net/http/RequestParser.java
@@ -291,8 +291,6 @@ public class RequestParser
 
 
   public static String getBaseDomain(String hostname){
-    String domain = "";
-
     // if hostname is an IP address return that address
     if(Patterns.IP_ADDRESS.matcher(hostname).matches())
       return hostname;
@@ -313,13 +311,19 @@ public class RequestParser
         if ((ihost - itld) == 0 || ihost == 2)
           return hostname;
 
-        domain = "";
+        StringBuilder sb = new StringBuilder();
+
         for(i = ihost - itld; i < ihost; i++){
-          domain += host_parts[i] + ".";
+          sb.append(host_parts[i]);
+          if(i < ihost - 1) {
+            sb.append(".");
+          }
         }
 
-        DNSCache.getInstance().addRootDomain(domain.substring(0, domain.length() - 1));
-        return domain.substring(0, domain.length() - 1);
+        String domain = sb.toString();
+
+        DNSCache.getInstance().addRootDomain(domain);
+        return domain;
       }
     }
 

--- a/cSploit/src/main/java/org/csploit/android/net/http/RequestParser.java
+++ b/cSploit/src/main/java/org/csploit/android/net/http/RequestParser.java
@@ -297,7 +297,7 @@ public class RequestParser
     if(Patterns.IP_ADDRESS.matcher(hostname).matches())
       return hostname;
 
-    String cached_domain = DNSCache.getInstance().getCachedRootDomain(hostname);
+    String cached_domain = DNSCache.getInstance().getRootDomain(hostname);
     if (cached_domain != null) {
       return cached_domain;
     }
@@ -318,7 +318,7 @@ public class RequestParser
           domain += host_parts[i] + ".";
         }
 
-        DNSCache.getInstance().addCachedRootDomain(domain.substring(0, domain.length() - 1));
+        DNSCache.getInstance().addRootDomain(domain.substring(0, domain.length() - 1));
         return domain.substring(0, domain.length() - 1);
       }
     }
@@ -333,7 +333,7 @@ public class RequestParser
     }
 
     if(startIndex > 0) {
-      DNSCache.getInstance().addCachedRootDomain(hostname.substring(startIndex));
+      DNSCache.getInstance().addRootDomain(hostname.substring(startIndex));
       return hostname.substring(startIndex);
     }
     else

--- a/cSploit/src/main/java/org/csploit/android/net/http/proxy/DNSCache.java
+++ b/cSploit/src/main/java/org/csploit/android/net/http/proxy/DNSCache.java
@@ -18,20 +18,22 @@
  */
 package org.csploit.android.net.http.proxy;
 
+import org.csploit.android.core.Logger;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.util.ArrayList;
 import java.util.HashMap;
 
 import javax.net.SocketFactory;
-
-import org.csploit.android.core.Logger;
 
 public class DNSCache
 {
   private static DNSCache mInstance = null;
 
   private HashMap<String, InetAddress> mCache = null;
+  private ArrayList<String> mCachedRootDomain = null;
 
   public static DNSCache getInstance(){
     if(mInstance == null)
@@ -42,6 +44,33 @@ public class DNSCache
 
   public DNSCache(){
     mCache = new HashMap<String, InetAddress>();
+    mCachedRootDomain = new ArrayList<String>();
+  }
+
+  /**
+   * checks if a domain ends with an already intercepted root domain.
+   *
+   * @param hostname hostname to check
+   * @return String the root domain or null
+   */
+  public String getCachedRootDomain (String hostname){
+    for (String rootDomain : mCachedRootDomain){
+      if (hostname.endsWith(rootDomain)){
+        return rootDomain;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Adds a root domain extracted from the domain of a request,
+   * to the list of intercepted root domains.
+   *
+   * @param rootdomain Root domain to add to the list
+   */
+  public void addCachedRootDomain (String rootdomain){
+    mCachedRootDomain.add(rootdomain);
   }
 
   private InetAddress getAddress(String server) throws IOException{

--- a/cSploit/src/main/java/org/csploit/android/net/http/proxy/DNSCache.java
+++ b/cSploit/src/main/java/org/csploit/android/net/http/proxy/DNSCache.java
@@ -32,8 +32,8 @@ public class DNSCache
 {
   private static DNSCache mInstance = new DNSCache();
 
-  private HashMap<String, InetAddress> mCache = null;
-  private ArrayList<String> mCachedRootDomain = null;
+  private final HashMap<String, InetAddress> mCache;
+  private final ArrayList<String> mRootDomainCache;
 
   public static DNSCache getInstance(){
     return mInstance;
@@ -41,7 +41,7 @@ public class DNSCache
 
   private DNSCache() {
     mCache = new HashMap<>();
-    mCachedRootDomain = new ArrayList<>();
+    mRootDomainCache = new ArrayList<>();
   }
 
   /**
@@ -50,10 +50,12 @@ public class DNSCache
    * @param hostname hostname to check
    * @return String the root domain or null
    */
-  public String getCachedRootDomain (String hostname){
-    for (String rootDomain : mCachedRootDomain){
-      if (hostname.endsWith(rootDomain)){
-        return rootDomain;
+  public String getRootDomain(String hostname){
+    synchronized (mRootDomainCache) {
+      for (String rootDomain : mRootDomainCache) {
+        if (hostname.endsWith(rootDomain)) {
+          return rootDomain;
+        }
       }
     }
 
@@ -66,8 +68,10 @@ public class DNSCache
    *
    * @param rootdomain Root domain to add to the list
    */
-  public void addCachedRootDomain (String rootdomain){
-    mCachedRootDomain.add(rootdomain);
+  public void addRootDomain(String rootdomain){
+    synchronized (mRootDomainCache) {
+      mRootDomainCache.add(rootdomain);
+    }
   }
 
   private InetAddress getAddress(String server) throws IOException{

--- a/cSploit/src/main/java/org/csploit/android/net/http/proxy/DNSCache.java
+++ b/cSploit/src/main/java/org/csploit/android/net/http/proxy/DNSCache.java
@@ -30,21 +30,18 @@ import javax.net.SocketFactory;
 
 public class DNSCache
 {
-  private static DNSCache mInstance = null;
+  private static DNSCache mInstance = new DNSCache();
 
   private HashMap<String, InetAddress> mCache = null;
   private ArrayList<String> mCachedRootDomain = null;
 
   public static DNSCache getInstance(){
-    if(mInstance == null)
-      mInstance = new DNSCache();
-
     return mInstance;
   }
 
-  public DNSCache(){
-    mCache = new HashMap<String, InetAddress>();
-    mCachedRootDomain = new ArrayList<String>();
+  private DNSCache() {
+    mCache = new HashMap<>();
+    mCachedRootDomain = new ArrayList<>();
   }
 
   /**


### PR DESCRIPTION
Whenever the mitm proxy receives a new connection to be forwarded to a remote server, we check if the victim: 1) is sending a cookie, 2) in such case we expire the cookie, 3) we set internally the domain which is visiting the victim as "cleaned".
Besides this, 4) when we intercept a cookie and add the domain to the list, if the cookie doesn't have the "domain" set, we get the base domain for it.

In all these 4 steps, we call getBaseDomain() which iterates over an array of ~1600 elements/TLDs and each iteration costs on average ~20-30ms, only for extract the root domain. So, for example on dx.com/c/consumer-electronics-199 we spend 2,7 secs just extracting the root domain of every downloaded resource (images, css, etc), which in the case of this url are 100 urls, which results in 100 calls to this method.

With this simple cache we save cpu time for other things, and speed up the performance on the module. It just takes 5-40ms for the request, and the rest are ~0ms.