### PR TITLE
put the items: network, gateway and our own device, on top of the hosts list

### DIFF
--- a/cSploit/src/main/java/org/csploit/android/core/System.java
+++ b/cSploit/src/main/java/org/csploit/android/core/System.java
@@ -1106,7 +1106,9 @@ public class System {
 
       boolean inserted = false;
 
-      for (int i = 0; i < mTargets.size(); i++) {
+      int start_idx = 3;
+      if(!mNetwork.haveGateway()) start_idx = 2;
+      for (int i = start_idx; i < mTargets.size(); i++) {
         if (mTargets.get(i).comesAfter(target)) {
           mTargets.add(i, target);
           inserted = true;

--- a/cSploit/src/main/java/org/csploit/android/helpers/NetworkHelper.java
+++ b/cSploit/src/main/java/org/csploit/android/helpers/NetworkHelper.java
@@ -1,5 +1,7 @@
 package org.csploit.android.helpers;
 
+import java.net.InetAddress;
+
 /**
  * A class that provide some useful network-related static methods
  */
@@ -20,5 +22,36 @@ public final class NetworkHelper {
    */
   public static int getOUICode(String hexOui) {
     return Integer.parseInt(hexOui, 16);
+  }
+
+  /**
+   * compare two byte[] comparing their length and each of their values.
+   * @return -1 if {@code a} is less than {@code b}, 0 if are equals, +1 if {@code a} is greater than {@code b}
+   */
+  public static int compareByteArray(byte[] a, byte[] b) {
+    int result;
+
+    result = a.length - b.length;
+
+    if(result != 0) {
+      return result;
+    }
+
+    for(int i = 0; i < a.length; i++) {
+      result = ((short) a[i] & 0xFF) - ((short) b[i] & 0xFF);
+      if(result != 0) {
+        return result;
+      }
+    }
+
+    return 0;
+  }
+
+  /**
+   * compare two {@link InetAddress}
+   * @return -1 if {@code a} is less than {@code b}, 0 if are equals, +1 if {@code a} is greater than {@code b}
+   */
+  public static int compareInetAddresses(InetAddress a, InetAddress b) {
+    return compareByteArray(a.getAddress(), b.getAddress());
   }
 }

--- a/cSploit/src/main/java/org/csploit/android/net/Endpoint.java
+++ b/cSploit/src/main/java/org/csploit/android/net/Endpoint.java
@@ -18,14 +18,17 @@
  */
 package org.csploit.android.net;
 
+import android.support.annotation.NonNull;
+
 import java.io.BufferedReader;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 import org.csploit.android.core.System;
+import org.csploit.android.helpers.NetworkHelper;
 
-public class Endpoint
+public class Endpoint implements Comparable<Endpoint>
 {
   private InetAddress mAddress = null;
   private byte[] mHardware = null;
@@ -99,14 +102,19 @@ public class Endpoint
       return mAddress.equals(endpoint.getAddress());
   }
 
-  public InetAddress getAddress(){
-    return mAddress;
+  @Override
+  public int compareTo(@NonNull Endpoint another) {
+    if(mHardware != null && another.mHardware != null) {
+      if(NetworkHelper.compareByteArray(mHardware, another.mHardware) == 0) {
+        return 0;
+      }
+    }
+
+    return NetworkHelper.compareInetAddresses(mAddress, another.mAddress);
   }
 
-  public long getAddressAsLong(){
-    byte[] baddr = mAddress.getAddress();
-
-    return ((baddr[0] & 0xFFl) << 24) + ((baddr[1] & 0xFFl) << 16) + ((baddr[2] & 0xFFl) << 8) + (baddr[3] & 0xFFl);
+  public InetAddress getAddress(){
+    return mAddress;
   }
 
   public void setAddress(InetAddress address){

--- a/cSploit/src/main/java/org/csploit/android/net/IP4Address.java
+++ b/cSploit/src/main/java/org/csploit/android/net/IP4Address.java
@@ -23,11 +23,11 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteOrder;
 
-public class IP4Address
+public class IP4Address implements Comparable<IP4Address>
 {
   private byte[] mByteArray = null;
   private String mString = "";
-  private int mInteger = 0;
+  private final int mInteger;
   private InetAddress mAddress = null;
 
   public static int ntohl(int n){
@@ -123,6 +123,11 @@ public class IP4Address
 
   public boolean equals(InetAddress address){
     return mAddress.equals(address);
+  }
+
+  @Override
+  public int compareTo(IP4Address another) {
+    return mInteger - another.mInteger;
   }
 
   public int getPrefixLength(){

--- a/cSploit/src/main/java/org/csploit/android/net/Network.java
+++ b/cSploit/src/main/java/org/csploit/android/net/Network.java
@@ -24,6 +24,7 @@ import android.net.DhcpInfo;
 import android.net.NetworkInfo;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
+import android.support.annotation.NonNull;
 import android.util.Patterns;
 
 import org.apache.commons.compress.utils.IOUtils;
@@ -49,7 +50,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class Network {
+public class Network implements Comparable<Network> {
   public enum Protocol {
     TCP,
     UDP,
@@ -337,6 +338,14 @@ public class Network {
 
   public InetAddress getLocalAddress() {
     return mLocal.toInetAddress();
+  }
+
+  @Override
+  public int compareTo(@NonNull Network another) {
+    if(mBase.equals(another.mBase)) {
+      return mNetmask.getPrefixLength() - another.mNetmask.getPrefixLength();
+    }
+    return mBase.compareTo(another.mBase);
   }
 
   private static boolean isIfaceConnected(NetworkInterface networkInterface) {

--- a/cSploit/src/test/java/org/csploit/android/helpers/NetworkHelperTest.java
+++ b/cSploit/src/test/java/org/csploit/android/helpers/NetworkHelperTest.java
@@ -3,6 +3,11 @@ package org.csploit.android.helpers;
 import junit.framework.Assert;
 import junit.framework.TestCase;
 
+import java.net.InetAddress;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+
 /**
  * Test NetworkHelper class
  */
@@ -15,5 +20,26 @@ public class NetworkHelperTest extends TestCase {
     int fromMAC = NetworkHelper.getOUICode(address);
 
     Assert.assertEquals(fromString + " differs from " + fromMAC, fromString, fromMAC);
+  }
+
+  public void testComapreInetAddress() throws Exception {
+    InetAddress a, b;
+
+    a = InetAddress.getLocalHost();
+    b = InetAddress.getByAddress("127.0.0.1", new byte[] {127, 0, 0, 1});
+
+    assertThat(a, is(b));
+
+    int res = NetworkHelper.compareInetAddresses(a, b);
+
+    assertThat(res, is(0));
+
+    b = InetAddress.getByAddress(new byte[] {(byte) 192, (byte) 168, 1, 1});
+
+    assertThat(a, not(b));
+
+    res = NetworkHelper.compareInetAddresses(a, b);
+
+    assertThat(a + " should be less than " + b, res < 0, is(true));
   }
 }


### PR DESCRIPTION
On networks with many hosts, if the gateway is for example the last IP on the range, you have to scroll down to select it, or simply for know which is it. On networks with 100, 200, or... 2000 hosts, this is a pain, and in the last case a nightmare.

I think that we should put the network range, the gateway, and our own device on top of the hosts list.
What do you think? and is this the right way of doing it?