### PR TITLE
Bring libraries up to alpha for sdk 24 & build tools to newer versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.1.0-alpha1'
     }
 }
 

--- a/cSploit/build.gradle
+++ b/cSploit/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.1.0-alpha1'
     }
 }
 
@@ -21,14 +21,14 @@ allprojects {
 apply plugin:  'com.android.application'
 
 dependencies {
-    compile 'com.android.support:support-v4:23.1.1'
-    compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.android.support:design:23.1.1'
-    compile 'com.android.support:preference-v7:23.1.1'
+    compile 'com.android.support:support-v4:24.0.0-alpha1'
+    compile 'com.android.support:appcompat-v7:24.0.0-alpha1'
+    compile 'com.android.support:design:24.0.0-alpha1'
+    compile 'com.android.support:preference-v7:23.2.0'
     compile 'org.apache.commons:commons-compress:1.10'
-    compile 'commons-net:commons-net:3.3'
+    compile 'commons-net:commons-net:3.4'
     compile 'com.github.zafarkhaja:java-semver:0.9.0'
-    compile 'org.unbescape:unbescape:1.1.1.RELEASE'
+    compile 'org.unbescape:unbescape:1.1.2.RELEASE'
     compile 'org.msgpack:msgpack:0.6.12'
     compile 'com.googlecode.juniversalchardet:juniversalchardet:1.0.3'
     compile 'org.tukaani:xz:1.5'
@@ -38,7 +38,7 @@ dependencies {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    buildToolsVersion '24.0.0 rc1'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
@@ -99,5 +99,8 @@ android {
             multiDexEnabled true
             return true
         }
+    }
+    dexOptions {
+        incremental false
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Nov 19 16:09:54 PST 2015
+#Wed Mar 02 15:50:34 PST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip


### PR DESCRIPTION
compile 'com.android.support:preference-v7:23.2.0' is still used as this has a
bug probably to be fixed in newer releases.

Also some external libraries have been updated as well.
