### PR TITLE
Adding character escaping functionality to packet forger

### DIFF
--- a/cSploit/src/main/java/org/csploit/android/plugins/PacketForger.java
+++ b/cSploit/src/main/java/org/csploit/android/plugins/PacketForger.java
@@ -44,6 +44,9 @@ import java.io.OutputStream;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.Socket;
+import java.util.ArrayList;
+import java.util.IllegalFormatCodePointException;
+import java.util.List;
 
 public class PacketForger extends Plugin implements OnClickListener {
 	private static final int TCP_PROTOCOL = 0;
@@ -135,7 +138,7 @@ public class PacketForger extends Plugin implements OnClickListener {
 									OutputStream writer = mSocket
 											.getOutputStream();
 
-									writer.write(data.getBytes());
+									writer.write(escapeInputString(data));
 									writer.flush();
 
 									if (waitResponse) {
@@ -291,5 +294,51 @@ public class PacketForger extends Plugin implements OnClickListener {
 		setStoppedState(null);
 		super.onBackPressed();
 		overridePendingTransition(R.anim.fadeout, R.anim.fadein);
+	}
+
+	private byte[] escapeInputString(String input) {
+		List<Byte> bytes = new ArrayList<>();
+		int currentIndex = 0;
+		int nextIndex = currentIndex;
+		byte addedByte = 0;
+
+		while (currentIndex < input.length()) {
+			addedByte = (byte)input.charAt(currentIndex);
+			if (input.charAt(currentIndex) == '\\') {
+				nextIndex = currentIndex + 1;
+				if (nextIndex >= input.length()) {
+					throw new IllegalArgumentException("Escaped string is malformed");
+				}
+				char modifier = input.charAt(nextIndex);
+				switch (modifier) {
+					case 'x':
+						if (nextIndex + 2 > input.length()) {
+							throw new IllegalArgumentException("Escaped string is malformed");
+						}
+						String x = input.substring(nextIndex + 1, nextIndex + 3);
+						addedByte = Byte.parseByte(x, 16);
+						nextIndex += 2;
+						break;
+					case 'r':
+						addedByte = (byte)0x0d;
+						break;
+					case 'n':
+						addedByte = (byte)0x0a;
+						break;
+					default:
+						throw new IllegalArgumentException("Escaped string is malformed");
+				}
+				currentIndex = nextIndex;
+			}
+			bytes.add(addedByte);
+			currentIndex++;
+		}
+
+		byte[] result = new byte[bytes.size()];
+		for (int i = 0; i < bytes.size(); ++i) {
+			result[i] = bytes.get(i);
+		}
+
+		return result;
 	}
 }

--- a/cSploit/src/main/java/org/csploit/android/plugins/PacketForger.java
+++ b/cSploit/src/main/java/org/csploit/android/plugins/PacketForger.java
@@ -303,7 +303,7 @@ public class PacketForger extends Plugin implements OnClickListener {
 
 		while (currentIndex < input.length()) {
 			addedByte = (byte)input.charAt(currentIndex);
-			if (input.charAt(currentIndex) == '\\') {
+			if (addedByte == '\\') {
 				nextIndex = currentIndex + 1;
 				if (nextIndex >= input.length()) {
 					throw new IllegalArgumentException("Escaped string is malformed");
@@ -323,6 +323,8 @@ public class PacketForger extends Plugin implements OnClickListener {
 						break;
 					case 'n':
 						addedByte = (byte)0x0a;
+						break;
+					case '\\':
 						break;
 					default:
 						throw new IllegalArgumentException("Escaped string is malformed");

--- a/cSploit/src/main/java/org/csploit/android/plugins/PacketForger.java
+++ b/cSploit/src/main/java/org/csploit/android/plugins/PacketForger.java
@@ -315,7 +315,7 @@ public class PacketForger extends Plugin implements OnClickListener {
 							throw new IllegalArgumentException("Escaped string is malformed");
 						}
 						String x = input.substring(nextIndex + 1, nextIndex + 3);
-						addedByte = Byte.parseByte(x, 16);
+						addedByte = (byte)Integer.parseInt(x, 16);
 						nextIndex += 2;
 						break;
 					case 'r':

--- a/cSploit/src/main/java/org/csploit/android/plugins/PacketForger.java
+++ b/cSploit/src/main/java/org/csploit/android/plugins/PacketForger.java
@@ -45,7 +45,6 @@ import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.Socket;
 import java.util.ArrayList;
-import java.util.IllegalFormatCodePointException;
 import java.util.List;
 
 public class PacketForger extends Plugin implements OnClickListener {


### PR DESCRIPTION
For #653 
Previously `PacketForger` would only send text, i.e. one could not add arbitrary byte values through escaping. This adds 3 escape sequences that are escaped before the input is sent down the output stream:
`\r` (Carriage Return - 0x0D)
`\n` (Linefeed - 0x0A)
`\xXX` (Arbitrary hex values in place of `XX`)
