### PR TITLE
Update everything to Android 3.2 canary 4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
+        google()
         jcenter()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:3.2.0-alpha03'
     }
 }
 
 allprojects {
     repositories {
+        google()
         jcenter()
         mavenCentral()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-alpha03'
+        classpath 'com.android.tools.build:gradle:3.2.0-alpha04'
     }
 }
 

--- a/cSploit/build.gradle
+++ b/cSploit/build.gradle
@@ -1,19 +1,17 @@
 buildscript {
     repositories {
+        google()
         jcenter()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:3.2.0-alpha03'
     }
-}
-
-def getDate() {
-    return Calendar.getInstance().getTimeInMillis();
 }
 
 allprojects {
     repositories {
+        google()
         jcenter()
         mavenCentral()
     }
@@ -21,28 +19,29 @@ allprojects {
 apply plugin:  'com.android.application'
 
 dependencies {
-    compile 'com.android.support:support-v4:23.1.1'
-    compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.android.support:design:23.1.1'
-    compile 'com.android.support:preference-v7:23.1.1'
-    compile 'org.apache.commons:commons-compress:1.10'
-    compile 'commons-net:commons-net:3.3'
-    compile 'com.github.zafarkhaja:java-semver:0.9.0'
-    compile 'org.unbescape:unbescape:1.1.1.RELEASE'
-    compile 'org.msgpack:msgpack:0.6.12'
-    compile 'com.googlecode.juniversalchardet:juniversalchardet:1.0.3'
-    compile 'org.tukaani:xz:1.5'
-    compile 'ch.acra:acra:4.6.2'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.android.support:support-v4:27.0.2'
+    implementation 'com.android.support:appcompat-v7:27.0.2'
+    implementation 'com.android.support:design:27.0.2'
+    implementation 'com.android.support:preference-v7:27.0.2'
+    implementation 'org.apache.commons:commons-compress:1.16.1'
+    implementation 'commons-net:commons-net:3.6'
+    implementation 'com.github.zafarkhaja:java-semver:0.9.0'
+    implementation 'org.unbescape:unbescape:1.1.5.RELEASE'
+    implementation 'org.msgpack:msgpack:0.6.12'
+    implementation 'com.googlecode.juniversalchardet:juniversalchardet:1.0.3'
+    implementation 'org.tukaani:xz:1.8'
+    implementation 'ch.acra:acra-http:5.1.0'
+    implementation 'ch.acra:acra-notification:5.1.0'
+    testImplementation 'junit:junit:4.12'
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     packagingOptions {
@@ -51,8 +50,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 22
+        minSdkVersion 14
+        targetSdkVersion 27
         versionCode 4
         versionName "1.7.0-unstable"
         if(System.getenv("NIGHTLY_BUILD")) {
@@ -81,8 +80,8 @@ android {
 
     buildTypes {
         debug {
-            buildConfigField "java.util.Date", "BUILD_TIME", "new java.util.Date(" + getDate() + "L)"
-            buildConfigField "String", "BUILD_NAME", "\"" + System.getenv("USER") + "\"";
+            buildConfigField "java.util.Date", "BUILD_TIME", "new java.util.Date(" + Calendar.getInstance().getTimeInMillis() + "L)"
+            buildConfigField "String", "BUILD_NAME", "\"" + System.getenv("USER") + "\""
             minifyEnabled false
             shrinkResources false
             debuggable true
@@ -91,8 +90,8 @@ android {
             multiDexEnabled true
         }
         release {
-            buildConfigField "java.util.Date", "BUILD_TIME", "new java.util.Date(" + getDate() + "L)"
-            buildConfigField "String", "BUILD_NAME", "\"" + System.getenv("USER") + "\"";
+            buildConfigField "java.util.Date", "BUILD_TIME", "new java.util.Date(" + Calendar.getInstance().getTimeInMillis() + "L)"
+            buildConfigField "String", "BUILD_NAME", "\"" + System.getenv("USER") + "\""
             if (System.getenv("KEYSTORE_FILE") != null) {
                 signingConfig signingConfigs.release
             }

--- a/cSploit/build.gradle
+++ b/cSploit/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-alpha03'
+        classpath 'com.android.tools.build:gradle:3.2.0-alpha04'
     }
 }
 
@@ -30,8 +30,8 @@ dependencies {
     implementation 'org.msgpack:msgpack:0.6.12'
     implementation 'com.googlecode.juniversalchardet:juniversalchardet:1.0.3'
     implementation 'org.tukaani:xz:1.8'
-    implementation 'ch.acra:acra-http:5.1.0'
-    implementation 'ch.acra:acra-notification:5.1.0'
+    implementation 'ch.acra:acra-http:5.1.1'
+    implementation 'ch.acra:acra-notification:5.1.1'
     testImplementation 'junit:junit:4.12'
 }
 

--- a/cSploit/src/main/AndroidManifest.xml
+++ b/cSploit/src/main/AndroidManifest.xml
@@ -14,14 +14,19 @@
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="18" />
-    <uses-permission android:name="android.permission.READ_LOGS" />
 
     <application
         android:name=".CSploitApplication"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:resizeableActivity="true">
+
+    <meta-data
+            android:name="android.max_aspect"
+            android:value="2.1" />
+
         <activity
             android:name=".MainActivity"
             android:configChanges="orientation|screenSize"
@@ -33,12 +38,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
-        <activity android:name="org.acra.CrashReportDialog"
-                  android:theme="@style/Theme.Dialog"
-                  android:launchMode="singleInstance"
-                  android:excludeFromRecents="true"
-                  android:finishOnTaskLaunch="true" />
 
         <!-- suppress AndroidDomInspection -->
         <service

--- a/cSploit/src/main/java/org/csploit/android/CSploitApplication.java
+++ b/cSploit/src/main/java/org/csploit/android/CSploitApplication.java
@@ -19,13 +19,19 @@
 package org.csploit.android;
 
 import android.app.Application;
+import android.content.Context;
 import android.content.SharedPreferences;
+import android.support.multidex.MultiDex;
 
 import org.acra.ACRA;
-import org.acra.ReportingInteractionMode;
-import org.acra.annotation.ReportsCrashes;
+import org.acra.annotation.AcraCore;
+import org.acra.annotation.AcraHttpSender;
+import org.acra.annotation.AcraNotification;
+import org.acra.config.CoreConfigurationBuilder;
+import org.acra.config.HttpSenderConfigurationBuilder;
+import org.acra.config.NotificationConfigurationBuilder;
+import org.acra.data.StringFormat;
 import org.acra.sender.HttpSender;
-import org.csploit.android.core.Logger;
 import org.csploit.android.core.System;
 import org.csploit.android.plugins.ExploitFinder;
 import org.csploit.android.plugins.Inspector;
@@ -40,19 +46,24 @@ import org.csploit.android.services.Services;
 
 import java.net.NoRouteToHostException;
 
-@ReportsCrashes(
+@AcraHttpSender(
   httpMethod = HttpSender.Method.PUT,
-  reportType = HttpSender.Type.JSON,
-  formUri = "http://csploit.iriscouch.com/acra-csploit/_design/acra-storage/_update/report",
-  formUriBasicAuthLogin = "android",
-  formUriBasicAuthPassword = "DEADBEEF",
-  mode = ReportingInteractionMode.DIALOG,
-  resDialogText = R.string.crash_dialog_text,
-  resDialogIcon = R.drawable.dsploit_icon,
-  resDialogTitle = R.string.crash_dialog_title,
-  resDialogCommentPrompt = R.string.crash_dialog_comment
+  uri = "http://csploit.iriscouch.com/acra-csploit/_design/acra-storage/_update/report",
+  basicAuthLogin = "android",
+  basicAuthPassword = "DEADBEEF"
 )
+@AcraNotification (
+        resChannelName = R.string.csploitChannelId,
+        resText = R.string.crash_dialog_text,
+        resIcon = R.drawable.dsploit_icon,
+        resTitle = R.string.crash_dialog_title,
+        resCommentPrompt = R.string.crash_dialog_comment
+)
+
+@AcraCore(applicationLogFile = "/cSploitd.log")
+
 public class CSploitApplication extends Application {
+
   @Override
   public void onCreate() {
     SharedPreferences themePrefs = getSharedPreferences("THEME", 0);
@@ -76,7 +87,11 @@ public class CSploitApplication extends Application {
         System.errorLogging(e);
     }
 
-    ACRA.setConfig(ACRA.getConfig().setApplicationLogFile(System.getCorePath() + "/cSploitd.log"));
+    CoreConfigurationBuilder builder = new CoreConfigurationBuilder(this);
+    builder.setBuildConfigClass(BuildConfig.class).setReportFormat(StringFormat.JSON);
+    builder.getPluginConfigurationBuilder(HttpSenderConfigurationBuilder.class);
+    builder.getPluginConfigurationBuilder(NotificationConfigurationBuilder.class);
+    ACRA.init(this, builder);
 
     // load system modules even if the initialization failed
     System.registerPlugin(new RouterPwn());
@@ -88,5 +103,12 @@ public class CSploitApplication extends Application {
     System.registerPlugin(new Sessions());
     System.registerPlugin(new MITM());
     System.registerPlugin(new PacketForger());
+  }
+
+  @Override
+  protected void attachBaseContext(Context base) {
+    super.attachBaseContext(base);
+    MultiDex.install(this);
+    ACRA.init(this);
   }
 }

--- a/cSploit/src/main/java/org/csploit/android/SettingsFragment.java
+++ b/cSploit/src/main/java/org/csploit/android/SettingsFragment.java
@@ -99,6 +99,7 @@ public class SettingsFragment extends Fragment {
 
             @Override
             public void onViewCreated(View v, Bundle savedInstanceState) {
+                super.onViewCreated(v, savedInstanceState);
                 SharedPreferences themePrefs = getActivity().getSharedPreferences("THEME", 0);
                 Boolean isDark = themePrefs.getBoolean("isDark", false);
                 if (isDark) {
@@ -140,7 +141,7 @@ public class SettingsFragment extends Fragment {
                 @Override
                 public boolean onPreferenceChange(Preference preference, Object newValue) {
                     SharedPreferences themePrefs = getActivity().getBaseContext().getSharedPreferences("THEME", 0);
-                    themePrefs.edit().putBoolean("isDark", (Boolean) newValue).commit();
+                    themePrefs.edit().putBoolean("isDark", (Boolean) newValue).apply();
                     Toast.makeText(getActivity().getBaseContext(), getString(R.string.please_restart), Toast.LENGTH_LONG).show();
                     return true;
                 }
@@ -276,7 +277,7 @@ public class SettingsFragment extends Fragment {
 
                 else {
                     //noinspection ConstantConditions
-                    getPreferenceManager().getSharedPreferences().edit().putString(key, path).commit();
+                    getPreferenceManager().getSharedPreferences().edit().putString(key, path).apply();
                     if (oldPath != null && !oldPath.equals(path)) {
                         File current = new File(oldPath);
 

--- a/cSploit/src/main/java/org/csploit/android/core/MultiAttackService.java
+++ b/cSploit/src/main/java/org/csploit/android/core/MultiAttackService.java
@@ -17,6 +17,7 @@ import org.csploit.android.net.metasploit.MsfExploit;
 import org.csploit.android.tools.NMap;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -84,8 +85,9 @@ public class MultiAttackService extends IntentService {
 
         synchronized (MultiAttackService.this) {
           completedTargets++;
-          mBuilder.setContentInfo(String.format("%d/%d",
-                  completedTargets, totalTargets));
+          mBuilder.setContentInfo(String.format(Locale.getDefault(), "%d/%d",
+                  completedTargets, totalTargets))
+                  .setChannelId(getBaseContext().getString(R.string.csploitChannelId));
           mNotificationManager.notify(NOTIFICATION_ID, mBuilder.build());
         }
 
@@ -199,7 +201,7 @@ public class MultiAttackService extends IntentService {
     // get notification manager
     mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
     // get notification builder
-    mBuilder = new NotificationCompat.Builder(this);
+    mBuilder = new NotificationCompat.Builder(this, getBaseContext().getString(R.string.csploitChannelId));
     // create a broadcast receiver to get actions
     // performed on the notification by the user
     mReceiver = new BroadcastReceiver() {
@@ -237,7 +239,8 @@ public class MultiAttackService extends IntentService {
       mBuilder.setContentIntent(PendingIntent.getActivity(this, CLICK_CODE, mContentIntent, 0))
               .setProgress(0,0,false)
               .setAutoCancel(true)
-              .setDeleteIntent(PendingIntent.getActivity(this, 0, new Intent(), 0));
+              .setDeleteIntent(PendingIntent.getActivity(this, 0, new Intent(), 0))
+              .setChannelId(getBaseContext().getString(R.string.csploitChannelId));
       mNotificationManager.notify(NOTIFICATION_ID, mBuilder.build());
     }
     if(mReceiver!=null)

--- a/cSploit/src/main/java/org/csploit/android/core/System.java
+++ b/cSploit/src/main/java/org/csploit/android/core/System.java
@@ -36,8 +36,7 @@ import android.os.PowerManager.WakeLock;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.util.SparseIntArray;
-import org.acra.ACRA;
-import org.acra.ACRAConfiguration;
+
 import org.apache.commons.compress.utils.IOUtils;
 import org.csploit.android.R;
 import org.csploit.android.WifiScannerFragment;
@@ -59,9 +58,36 @@ import org.csploit.android.net.metasploit.Session;
 import org.csploit.android.services.Services;
 import org.csploit.android.tools.ToolBox;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NoRouteToHostException;
+import java.net.Socket;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Observer;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
@@ -271,12 +297,12 @@ public class System {
     if (ret != 0) {
       File log = new File(System.getCorePath(), "cSploitd.log");
       DaemonException daemonException = new DaemonException("core daemon returned " + ret);
-      if (log.exists() && log.canRead()) {
+   /*   if (log.exists() && log.canRead()) {
         ACRAConfiguration conf = ACRA.getConfig();
         conf.setApplicationLogFile(log.getAbsolutePath());
         ACRA.setConfig(conf);
         ACRA.getErrorReporter().handleException(daemonException, false);
-      }
+      }*/
       throw daemonException;
     }
   }

--- a/cSploit/src/main/java/org/csploit/android/services/UpdateService.java
+++ b/cSploit/src/main/java/org/csploit/android/services/UpdateService.java
@@ -243,7 +243,7 @@ public class UpdateService extends IntentService
     // get notification manager
     mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
     // get notification builder
-    mBuilder = new NotificationCompat.Builder(this);
+    mBuilder = new NotificationCompat.Builder(this, getBaseContext().getString(R.string.csploitChannelId));
     // create a broadcast receiver to get actions
     // performed on the notification by the user
     mReceiver = new BroadcastReceiver() {
@@ -283,7 +283,8 @@ public class UpdateService extends IntentService
     } else {
       Logger.debug("assign '"+contentIntent.toString()+"' to notification");
      if(mBuilder!=null&&mNotificationManager!=null) {
-       mBuilder.setContentIntent(PendingIntent.getActivity(this, DOWNLOAD_COMPLETE_CODE, contentIntent, 0));
+       mBuilder.setContentIntent(PendingIntent.getActivity(this, DOWNLOAD_COMPLETE_CODE, contentIntent, 0))
+               .setChannelId(getBaseContext().getString(R.string.csploitChannelId));
        mNotificationManager.notify(NOTIFICATION_ID, mBuilder.build());
      }
     }
@@ -342,7 +343,8 @@ public class UpdateService extends IntentService
             .setSmallIcon(android.R.drawable.ic_popup_sync)
             .setContentText("")
             .setContentInfo("")
-            .setProgress(100, 0, true);
+            .setProgress(100, 0, true)
+            .setChannelId(getBaseContext().getString(R.string.csploitChannelId));
     mNotificationManager.notify(NOTIFICATION_ID,mBuilder.build());
 
     f = new File(mCurrentTask.path);
@@ -385,7 +387,8 @@ public class UpdateService extends IntentService
         percentage = (short) (((double) counter.getBytesRead() / total) * 100);
         if (percentage != old_percentage) {
           mBuilder.setProgress(100, percentage, false)
-                  .setContentInfo(percentage + "%");
+                  .setContentInfo(percentage + "%")
+                  .setChannelId(getBaseContext().getString(R.string.csploitChannelId));
           mNotificationManager.notify(NOTIFICATION_ID, mBuilder.build());
           old_percentage = percentage;
         }
@@ -455,7 +458,8 @@ public class UpdateService extends IntentService
         mBuilder.setContentTitle(getString(R.string.checking))
                 .setSmallIcon(android.R.drawable.ic_popup_sync)
                 .setContentText("")
-                .setProgress(100, 0, false);
+                .setProgress(100, 0, false)
+                .setChannelId(getBaseContext().getString(R.string.csploitChannelId));
         mNotificationManager.notify(NOTIFICATION_ID,mBuilder.build());
 
         md5 = (mCurrentTask.md5!=null ? MessageDigest.getInstance("MD5") : null);
@@ -473,7 +477,8 @@ public class UpdateService extends IntentService
           percentage = (short) (((double) read_counter / total) * 100);
           if (percentage != previous_percentage) {
             mBuilder.setProgress(100, percentage, false)
-                    .setContentInfo(percentage + "%");
+                    .setContentInfo(percentage + "%")
+                    .setChannelId(getBaseContext().getString(R.string.csploitChannelId));
             mNotificationManager.notify(NOTIFICATION_ID, mBuilder.build());
             previous_percentage = percentage;
           }
@@ -542,7 +547,8 @@ public class UpdateService extends IntentService
       mBuilder.setContentTitle(getString(R.string.downloading_update))
               .setContentText(getString(R.string.connecting))
               .setSmallIcon(android.R.drawable.stat_sys_download)
-              .setProgress(100, 0, true);
+              .setProgress(100, 0, true)
+              .setChannelId(getBaseContext().getString(R.string.csploitChannelId));
       mNotificationManager.notify(NOTIFICATION_ID,mBuilder.build());
 
       md5 = (mCurrentTask.md5!=null  ? MessageDigest.getInstance("MD5") : null);
@@ -573,7 +579,8 @@ public class UpdateService extends IntentService
       downloaded=0;
       previous_percentage=-1;
 
-      mBuilder.setContentText(file.getName());
+      mBuilder.setContentText(file.getName())
+              .setChannelId(getBaseContext().getString(R.string.csploitChannelId));
       mNotificationManager.notify(NOTIFICATION_ID, mBuilder.build());
 
       Logger.info(String.format("downloading '%s' to '%s'", mCurrentTask.url, mCurrentTask.path));
@@ -592,7 +599,8 @@ public class UpdateService extends IntentService
 
           if (percentage != previous_percentage) {
             mBuilder.setProgress(100, percentage, false)
-                    .setContentInfo(percentage + "%");
+                    .setContentInfo(percentage + "%")
+                    .setChannelId(getBaseContext().getString(R.string.csploitChannelId));
             mNotificationManager.notify(NOTIFICATION_ID, mBuilder.build());
             previous_percentage = percentage;
           }
@@ -663,7 +671,8 @@ public class UpdateService extends IntentService
             .setContentText("")
             .setContentInfo("")
             .setSmallIcon(android.R.drawable.ic_popup_sync)
-            .setProgress(100, 0, false);
+            .setProgress(100, 0, false)
+            .setChannelId(getBaseContext().getString(R.string.csploitChannelId));
     mNotificationManager.notify(NOTIFICATION_ID,mBuilder.build());
 
     Logger.info(String.format("extracting '%s' to '%s'", mCurrentTask.path, mCurrentTask.outputDir));
@@ -782,7 +791,8 @@ public class UpdateService extends IntentService
           percentage = (short) (((double) counter.getBytesRead() / total) * 100);
           if (percentage != old_percentage) {
             mBuilder.setProgress(100, percentage, false)
-                    .setContentInfo(percentage + "%");
+                    .setContentInfo(percentage + "%")
+                    .setChannelId(getBaseContext().getString(R.string.csploitChannelId));
             mNotificationManager.notify(NOTIFICATION_ID, mBuilder.build());
             old_percentage = percentage;
           }
@@ -823,7 +833,8 @@ public class UpdateService extends IntentService
         Logger.info(".nomedia created");
 
       mBuilder.setContentInfo("")
-              .setProgress(100, 100, true);
+              .setProgress(100, 100, true)
+              .setChannelId(getBaseContext().getString(R.string.csploitChannelId));
       mNotificationManager.notify(NOTIFICATION_ID, mBuilder.build());
     } finally {
       if(is != null)
@@ -843,7 +854,8 @@ public class UpdateService extends IntentService
             .setContentText(getString(R.string.installing_bundle))
             .setContentInfo("")
             .setSmallIcon(android.R.drawable.stat_sys_download)
-            .setProgress(100, 0, true);
+            .setProgress(100, 0, true)
+            .setChannelId(getBaseContext().getString(R.string.csploitChannelId));
     mNotificationManager.notify(NOTIFICATION_ID, mBuilder.build());
     Child bundleInstallTask;
 
@@ -855,7 +867,8 @@ public class UpdateService extends IntentService
         bundleInstallTask = System.getTools().ruby.async("gem install bundle", mErrorReceiver);
       }
 
-      mBuilder.setContentText(getString(R.string.installing_msf_gems));
+      mBuilder.setContentText(getString(R.string.installing_msf_gems))
+              .setChannelId(getBaseContext().getString(R.string.csploitChannelId));
       mNotificationManager.notify(NOTIFICATION_ID, mBuilder.build());
 
       // remove cache version file

--- a/cSploit/src/main/java/org/csploit/android/services/receivers/MsfRpcdServiceReceiver.java
+++ b/cSploit/src/main/java/org/csploit/android/services/receivers/MsfRpcdServiceReceiver.java
@@ -69,12 +69,13 @@ public class MsfRpcdServiceReceiver extends ManagedReceiver {
 
   private void updateNotificationForStatus(Context context, MsfRpcdService.Status status) {
     NotificationCompat.Builder mBuilder =
-            new NotificationCompat.Builder(context)
+            new NotificationCompat.Builder(context, context.getString(R.string.csploitChannelId))
             .setSmallIcon(R.drawable.exploit_msf)
             .setContentTitle(context.getString(R.string.msf_status))
             .setProgress(0, 0, status.inProgress())
             .setContentText(context.getString(status.getText()))
-            .setColor(ContextCompat.getColor(context, status.getColor()));
+            .setColor(ContextCompat.getColor(context, status.getColor()))
+            .setChannelId(context.getString(R.string.csploitChannelId));
 
     NotificationManager mNotificationManager =
             (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);

--- a/cSploit/src/main/res/values/strings.xml
+++ b/cSploit/src/main/res/values/strings.xml
@@ -537,4 +537,12 @@
     <string name="connection_lost_prompt">delete current session and start another?</string>
     <string name="any_interface">any interface</string>
     <string name="error_initializing_interface">Error initializing %s</string>
+
+    <!-- notification channel-->
+    <string name="csploitChannelId" translatable="false">csploit_channel</string>
+    <string name="cSploitChannelDescription" >cSploit-related messages</string>
+
+    <!-- permissions -->
+    <string name="permissions_fail">Sorry, you need to approve both permission requests.</string>
+    <string name="permissions_succeed">Thanks!</string>
 </resources>

--- a/cSploit/src/main/res/values/style.xml
+++ b/cSploit/src/main/res/values/style.xml
@@ -47,8 +47,6 @@
         <item name="android:windowBackground">@color/background_window_dark</item>
     </style>
 
-    <style name="Theme.Dialog" parent="@android:style/Theme.Dialog" />
-
     <style name="AppAnimation" parent="android:Animation.Dialog">
         <item name="android:inAnimation">@anim/fadein</item>
         <item name="android:outAnimation">@anim/fadein</item>

--- a/cSploit/src/main/res/xml/preferences.xml
+++ b/cSploit/src/main/res/xml/preferences.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.v7.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -234,4 +234,4 @@
             android:title="@string/pref_msf_delete" />
     </PreferenceCategory>
 
-</PreferenceScreen>
+</android.support.v7.preference.PreferenceScreen>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Nov 19 16:09:54 PST 2015
+#Tue Oct 17 19:27:29 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-all.zip


### PR DESCRIPTION
While waiting for cSploit 2.0 to come online, I got bored.  So for anyone still using it, here's a quick refresh.

**Note that I have not tested on a physical Oreo device as I don't have one and the oreo emulator is x86 only.**  I do have commit rights, but wanted to let people try it out before I add to `devel` or `master` or wherever.  Cheers!

* target API/sdk 27, support as far back as 14 (from 9)
* update to newest libraries and use new "implementation" build.gradle syntax
* Update Java from 1.7 to 1.8
* Update to gradle 4.5.1 from 2.9
* Update android gradle plugin from 1.5.0 to 3.2.0-a2
* Use the google dependency repository
* simplify build.gradle date stamp calculation
* update ACRA (even though target end point @ iriscouch went offline).
  This is not really tested past the "send info" dialog (no point)
* Support multi-window on chromebook.
* Add Notification Channel as required by Oreo (Android 8)
* Add very simple runtime permissions request
* Minor changes to use .apply() instead of .commit()
* Similar minor fix to use Locale with string formatting.
* Minor removal of dialog theme defining itself
* Fix bug in SettingsFragment where super.onViewCreated() not called
* Minor fix to preferences compat xml file

Th-that's all, folks!